### PR TITLE
add minIni

### DIFF
--- a/system/minIni/Kconfig
+++ b/system/minIni/Kconfig
@@ -1,6 +1,6 @@
 
 config PKG_USING_MININI
-    bool "minIni£ºa portable and configurable library for reading and writing ".INI" files."
+    bool "minIni: a portable and configurable library for reading and writing ".INI" files."
     default n
 
 if PKG_USING_MININI
@@ -22,6 +22,6 @@ if PKG_USING_MININI
     endchoice
     
     default "v1.2.0" if PKG_USING_MININI_V120
-    default xxx
+    default "v1.2.0"
 
 endif

--- a/system/minIni/Kconfig
+++ b/system/minIni/Kconfig
@@ -1,0 +1,36 @@
+
+config PKG_USING_MININI
+    bool "a minIni package for rt-thread"
+    default n
+
+if PKG_USING_MININI
+
+    config PKG_MININI_PATH
+        string
+        default "/packages/system/minIni"
+
+    choice
+        prompt "minIni version"
+        help
+            Select the minIni version
+
+        config PKG_USING_MININI_V120
+            bool "v1.2.0"
+
+        config PKG_USING_MININI_LATEST_VERSION
+            bool "latest_version"
+    endchoice
+    
+    if PKG_USING_MININI_V120
+        config PKG_MININI_VER
+        string
+        default "v1.2.0"
+    endif
+   
+    if PKG_USING_MININI_LATEST_VERSION
+       config PKG_MININI_VER
+       string
+       default "latest_version"    
+    endif
+
+endif

--- a/system/minIni/Kconfig
+++ b/system/minIni/Kconfig
@@ -1,6 +1,6 @@
 
 config PKG_USING_MININI
-    bool "a minIni package for rt-thread"
+    bool "minIni£ºa portable and configurable library for reading and writing ".INI" files."
     default n
 
 if PKG_USING_MININI
@@ -21,16 +21,7 @@ if PKG_USING_MININI
             bool "latest_version"
     endchoice
     
-    if PKG_USING_MININI_V120
-        config PKG_MININI_VER
-        string
-        default "v1.2.0"
-    endif
-   
-    if PKG_USING_MININI_LATEST_VERSION
-       config PKG_MININI_VER
-       string
-       default "latest_version"    
-    endif
+    default "v1.2.0" if PKG_USING_MININI_V120
+    default xxx
 
 endif

--- a/system/minIni/package.json
+++ b/system/minIni/package.json
@@ -1,7 +1,7 @@
 
 {
     "name": "minIni",
-    "description": "a minIni package for rt-thread",
+    "description": "minIni: a portable and configurable library for reading and writing ".INI" files.",
     "keywords": [
         "minIni"
     ],

--- a/system/minIni/package.json
+++ b/system/minIni/package.json
@@ -1,0 +1,13 @@
+
+{
+    "name": "minIni",
+    "description": "a minIni package for rt-thread",
+    "keywords": [
+        "minIni"
+    ],
+    "readme": "a minIni package for rt-thread",
+    "site" : [
+    {"version" : "v1.2.0", "URL" : "https://github.com/hichard/minIni.git", "filename" : "minIni-1.2.0.zip","VER_SHA" : "5bb0bd7ca1e6dbabef4eea7df3a1acc6400f7fcc"},
+    {"version" : "latest_version", "URL" : "https://github.com/hichard/minIni.git", "filename" : "minIni-1.2.0.zip","VER_SHA" : "mater"}
+    ]
+}


### PR DESCRIPTION
Add minIni library for rt-thread. minIni is a portable and configurable library for reading and writing ".INI" files.