### PR TITLE
Add mupdf package to multimedia.

### DIFF
--- a/multimedia/Kconfig
+++ b/multimedia/Kconfig
@@ -1,5 +1,6 @@
 menu "multimedia packages"
 
 source "$PKGS_DIR/packages/multimedia/openmv/Kconfig"
+source "$PKGS_DIR/packages/multimedia/mupdf/Kconfig"
 
 endmenu

--- a/multimedia/mupdf/Kconfig
+++ b/multimedia/mupdf/Kconfig
@@ -1,0 +1,38 @@
+
+# Kconfig file for package mupdf
+config PKG_USING_MUPDF
+    bool "mupdf: a lightweight PDF, XPS, and E-book viewer"
+    default n
+
+if PKG_USING_MUPDF
+
+    config PKG_MUPDF_PATH
+        string
+        default "/packages/multimedia/mupdf"
+
+    choice
+        prompt "mupdf version"
+        help
+            Select the mupdf version
+
+        config PKG_USING_MUPDF_V120
+            bool "v1.2.0"
+
+        config PKG_USING_MUPDF_LATEST_VERSION
+            bool "latest"
+    endchoice
+    
+    if PKG_USING_MUPDF_V120
+        config PKG_MUPDF_VER
+        string
+        default "v1.2.0"
+    endif
+   
+    if PKG_USING_MUPDF_LATEST_VERSION
+       config PKG_MUPDF_VER
+       string
+       default "latest"    
+    endif
+
+endif
+

--- a/multimedia/mupdf/package.json
+++ b/multimedia/mupdf/package.json
@@ -1,0 +1,12 @@
+
+{
+    "name": "mupdf",
+    "description": "mupdf: a lightweight PDF, XPS, and E-book viewer",
+    "keywords": [
+        "mupdf"
+    ],
+    "site" : [
+    {"version" : "v1.2.0", "URL" : "https://github.com/rtoslab/mupdf-rtt/archive/v0.1-alpha.zip", "filename" : "v0.1-alpha.zip","VER_SHA" : "4da369abd6de7373724e47f4401e77aca6749d82"},
+    {"version" : "latest", "URL" : "https://github.com/rtoslab/mupdf-rtt.git", "filename" : "mupdf-rtt.zip","VER_SHA" : "mater"}
+    ]
+}


### PR DESCRIPTION
Add mupdf package to multimedia. Currently, this work is based on an old version of mupdf v1.2.0.