### PR TITLE
增加STM32F405的STD库和驱动的包

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -5,4 +5,6 @@ menu "peripheral libraries and drivers"
 source "$PKGS_DIR/packages/peripherals/ST_STM32F4_HAL/Kconfig"
 source "$PKGS_DIR/packages/peripherals/STM32F4_Drivers/Kconfig"
 
+source "$PKGS_DIR/packages/peripherals/stm32f40x-drivers/Kconfig"
+source "$PKGS_DIR/packages/peripherals/stm32f40x-stdlibraries/Kconfig"
 endmenu

--- a/peripherals/stm32f40x-drivers/Kconfig
+++ b/peripherals/stm32f40x-drivers/Kconfig
@@ -1,0 +1,28 @@
+config PKG_USING_STM32F40X_Drivers
+    bool "STM32F40X_Drivers: RT-Thread Drivers for STM32F4 Series"
+    default n
+
+if PKG_USING_STM32F40X_Drivers
+
+    config PKG_STM32F40X_Drivers_PATH
+        string
+        default "/packages/peripherals/stm32f40x-drivers"
+
+    choice
+        prompt "Version"
+        help 
+            Select this package version
+
+        config PKG_USING_STM32F40X_Drivers_V10000
+            bool "v1.0.0"
+
+        config PKG_USING_STM32F40X_Drivers_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_STM32F40X_Drivers_VER
+        string
+        default "v1.0.0" if PKG_USING_STM32F40X_Drivers_V10000
+        default "latest" if PKG_USING_STM32F40X_Drivers_LATEST_VERSION
+
+endif

--- a/peripherals/stm32f40x-drivers/package.json
+++ b/peripherals/stm32f40x-drivers/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "STM32F40X_Drivers",
+    "description": "STM32F40x_Drivers: RT-Thread Drivers for STM32F4 series SoC",
+    "keywords": [
+        "Drivers", "STM32F40X"
+    ],
+    "readme": "STM32F40x_Drivers: RT-Thread Drivers for STM32F4 series SoC",
+    "site" : [
+    {"version": "v1.0.0", "URL": "https://github.com/slcmcu/stm32f40x-drivers/archive/v1.0.0.zip", "filename": "STM32F4_Drivers-1.0.0.zip"},
+    {"version": "latest", "URL": "https://github.com/slcmcu/stm32f40x-drivers.git", "filename": "STM32F4_Drivers.zip", "VER_SHA": "master"}
+    ]
+}

--- a/peripherals/stm32f40x-stdlibraries/Kconfig
+++ b/peripherals/stm32f40x-stdlibraries/Kconfig
@@ -1,0 +1,28 @@
+config PKG_USING_STM32F40X_STD
+    bool "STM32F40X_STD: STM32F40x STD library"
+    default n
+
+if PKG_USING_STM32F40X_STD
+
+    config PKG_STM32F40X_STD_PATH
+        string
+        default "/packages/peripherals/stm32f40x-stdlibraries"
+
+    choice
+        prompt "Version"
+        help 
+            Select this package version
+
+        config PKG_USING_STM32F40X_STD_V10000
+            bool "v1.0.0"
+
+        config PKG_USING_STM32F40X_STD_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_STM32F40X_STD_VER
+        string
+        default "v1.0.0" if PKG_USING_STM32F40X_STD_V10000
+        default "latest" if PKG_USING_STM32F40X_STD_LATEST_VERSION
+
+endif

--- a/peripherals/stm32f40x-stdlibraries/package.json
+++ b/peripherals/stm32f40x-stdlibraries/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "STM32F40X_STD",
+    "description": "STM32F40X_STD: HAL Library for STM32F40X series SoC",
+    "keywords": [
+        "STM32F40X_STD", "Peripheral Library"
+    ],
+    "readme": "STD Peripheral Library for STM32F40X series SoC",
+    "site" : [
+    {"version": "v1.0.0", "URL": "https://github.com/slcmcu/stm32f40x-stdlibraries/archive/v1.0.0.zip", "filename": "STM32F4_STD-1.0.0.zip"},
+    {"version": "latest", "URL": "https://github.com/slcmcu/stm32f40x-stdlibraries.git", "filename": "STM32F4_STD.zip", "VER_SHA": "master"}
+    ]
+}


### PR DESCRIPTION
1.基于STM32F40X的BSP,将其中的驱动和库做成包的形式
2.这里是提交的与包有关系的脚本程序代码
3.使用STM32F405开发进行测试