### PR TITLE
[add] add optparse(getopt-like) pkg support. | 添加optparse(类getopt)包支持.

### DIFF
--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -1,5 +1,6 @@
 menu "miscellaneous packages"
 
+source "$PKGS_DIR/packages/misc/optparse/Kconfig"
 source "$PKGS_DIR/packages/misc/fastlz/Kconfig"
 source "$PKGS_DIR/packages/misc/miniLZO/Kconfig"
 source "$PKGS_DIR/packages/misc/quicklz/Kconfig"

--- a/misc/optparse/Kconfig
+++ b/misc/optparse/Kconfig
@@ -1,0 +1,34 @@
+# Kconfig file for package optparse 
+menuconfig PKG_USING_OPTPARSE  
+    bool "optparse: a public domain, portable, reentrant, embeddable, getopt-like option parser."
+    default n
+
+if PKG_USING_OPTPARSE
+
+    config PKG_OPTPARSE_PATH
+        string
+        default "/packages/misc/optparse"
+
+    choice
+        prompt "optparse version"
+        help
+            Select the optparse version 
+
+        config PKG_USING_OPTPARSE_V100 
+            bool "v1.0.0"
+
+        config PKG_USING_OPTPARSE_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_OPTPARSE_VER
+        string
+        default "v1.0.0" if PKG_USING_OPTPARSE_V100
+        default "latest" if PKG_USING_OPTPARSE_LATEST_VERSION
+        
+    config OPTPARSE_USING_DEMO
+        bool
+        prompt "optparse demo example"
+        default n
+
+endif

--- a/misc/optparse/package.json
+++ b/misc/optparse/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "optparse",
+    "description": "optparse: a public domain, portable, reentrant, embeddable, getopt-like option parser.",
+    "keywords": [
+        "getopt-like"
+    ],
+    "License" : "UNLICENSE License",
+    "readme": "optparse: a public domain, portable, reentrant, embeddable, getopt-like option parser.",
+    "author": {
+        "name" : "liu2guang",
+        "email": "1004383796@qq.com"
+    },
+    "site" : [
+        {"version" : "v1.0.0", "URL" : "https://github.com/liu2guang/optparse.git", "filename" : "optparse-v1.0.0.zip", "VER_SHA" : "1b55de5596c9010b507a03311f54f144305fd414"}, 
+        {"version" : "latest", "URL" : "https://github.com/liu2guang/optparse.git", "filename" : "optparse-latest.zip", "VER_SHA" : "master"}
+    ]
+}


### PR DESCRIPTION
optparse是一个开源, 可移植的, 可重入的和可嵌入的类getopt命令行参数解析器. 它支持POSIX getopt选项字符串, GNU风格的长参数解析, 参数置换和子命令处理.