### PR TITLE
Add u8g2 library, a library for monochrome displays

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -8,5 +8,6 @@ source "$PKGS_DIR/packages/peripherals/aht10/Kconfig"
 source "$PKGS_DIR/packages/peripherals/ap3216c/Kconfig"
 source "$PKGS_DIR/packages/peripherals/stm32_sdio/Kconfig"
 source "$PKGS_DIR/packages/peripherals/icm20608/Kconfig"
+source "$PKGS_DIR/packages/peripherals/u8g2/Kconfig"
 
 endmenu

--- a/peripherals/u8g2/Kconfig
+++ b/peripherals/u8g2/Kconfig
@@ -1,0 +1,34 @@
+
+# Kconfig file for package u8g2
+menuconfig PKG_USING_U8G2
+    bool "U8G2: a u8g2 package for rt-thread"
+    default n
+    select RT_USING_I2C
+    select RT_USING_I2C_BITOPS
+
+if PKG_USING_U8G2
+
+    config PKG_U8G2_PATH
+        string
+        default "/packages/peripherals/u8g2"
+
+    choice
+        prompt "Version"
+        default PKG_USING_U8G2_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_U8G2_V100
+            bool "v1.0.0"
+
+        config PKG_USING_U8G2_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_U8G2_VER
+       string
+       default "v1.0.0"    if PKG_USING_U8G2_V100
+       default "latest"    if PKG_USING_U8G2_LATEST_VERSION
+
+endif
+

--- a/peripherals/u8g2/package.json
+++ b/peripherals/u8g2/package.json
@@ -6,7 +6,7 @@
         "u8g2"
     ],
     "site" : [
-    {"version" : "v1.0.0", "URL" : "https://github.com/wuhanstudio/u8g2-1.0.0.zip", "filename" : "u8g2-1.0.0.zip","VER_SHA" : "fill in the git version SHA value"},
+    {"version" : "v1.0.0", "URL" : "https://github.com/wuhanstudio/rt-u8g2.git", "filename" : "u8g2-1.0.0.zip","VER_SHA" : "362a24eb31c282c9d6587a89b72fc8a0bbd248e5"},
     {"version" : "latest", "URL" : "https://github.com/wuhanstudio/rt-u8g2.git", "filename" : "","VER_SHA" : "mater"}
     ]
 }

--- a/peripherals/u8g2/package.json
+++ b/peripherals/u8g2/package.json
@@ -1,0 +1,12 @@
+
+{
+    "name": "u8g2",
+    "description": "a u8g2 package for rt-thread",
+    "keywords": [
+        "u8g2"
+    ],
+    "site" : [
+    {"version" : "v1.0.0", "URL" : "https://github.com/wuhanstudio/u8g2-1.0.0.zip", "filename" : "u8g2-1.0.0.zip","VER_SHA" : "fill in the git version SHA value"},
+    {"version" : "latest", "URL" : "https://github.com/wuhanstudio/rt-u8g2.git", "filename" : "","VER_SHA" : "mater"}
+    ]
+}


### PR DESCRIPTION
u8g2 是一个液晶显示屏驱动，支持非常多的液晶屏:

    SSD1305, SSD1306, SSD1309, SSD1322, SSD1325, SSD1327, SSD1329, SSD1606, SSD1607, SH1106, 
    SH1107, SH1108, SH1122, T6963, RA8835, LC7981, PCD8544, PCF8812, HX1230, UC1601, UC1604,  
    UC1608, UC1610, UC1611, UC1701, ST7565, ST7567, ST7588, ST75256, NT7534, IST3020, ST7920, 
    LD7032, KS0108, SED1520, SBN1661, IL3820, MAX7219 ...

原始项目地址: 

> [https://github.com/olikraus/u8g2](https://github.com/olikraus/u8g2)

ARM Linux 移植: 

> [https://github.com/wuhanstudio/u8g2-arm-linux](https://github.com/olikraus/u8g2)

在征得原作者 [许可](https://github.com/olikraus/u8g2/issues/711) 的情况下，我在尝试把它移植到不同平台，在 rt-thread 上的 [I2C 液晶屏](https://github.com/wuhanstudio/rt-u8g2/tree/master/examples) 已经能正常工作了，之后也会支持 SPI 和 GPIO.