### PR TITLE
更新外设-按键驱动，已经测试完成，

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -9,5 +9,6 @@ source "$PKGS_DIR/packages/peripherals/ap3216c/Kconfig"
 source "$PKGS_DIR/packages/peripherals/stm32_sdio/Kconfig"
 source "$PKGS_DIR/packages/peripherals/icm20608/Kconfig"
 source "$PKGS_DIR/packages/peripherals/u8g2/Kconfig"
+source "$PKGS_DIR/packages/peripherals/button/Kconfig"
 
 endmenu

--- a/peripherals/button/Kconfig
+++ b/peripherals/button/Kconfig
@@ -1,0 +1,74 @@
+
+# Kconfig file for package button
+menuconfig PKG_USING_BUTTON
+    bool "button drive by C, support single and double click, long press, long press release"
+    default n
+
+if PKG_USING_BUTTON
+
+    config PKG_BUTTON_PATH 
+        string
+        default "/packages/peripherals/button"
+		
+    config SINGLE_AND_DOUBLE_TRIGGER
+        bool "support single and double click"
+        default y
+		
+    config CONTINUOS_TRIGGER
+        bool "support continuos trigger"
+        default n
+		
+    config LONG_FREE_TRIGGER
+        bool "support long press release"
+        default n	
+		
+	config BUTTON_DEBOUNCE_TIME
+		int "This value is the button debounce time"
+		default 2  
+		help
+			"This value = (n-1)*(button processing callback cycle)"
+			
+	config BUTTON_CONTINUOS_CYCLE
+		int "This value is the button press the trigger cycle continuously"
+		default 1  
+		help
+			"This value = (n-1)*(button processing callback cycle)"	
+			
+	config BUTTON_LONG_CYCLE
+		int "This value is the button long press cycle time"
+		default 1  
+		help
+			"This value = (n-1)*(button processing callback cycle)"
+			
+	config BUTTON_DOUBLE_TIME
+		int "This value is the button double click time"
+		default 15  
+		help
+			"This value = (n-1)*(button processing callback cycle)"		
+			
+	config BUTTON_LONG_TIME
+		int "This value is the button long press time"
+		default 50  
+		help
+			"This value = (n-1)*(button processing callback cycle)"		
+			
+    choice
+        prompt "Version"
+        default PKG_USING_BUTTON_V100
+        help
+            Select the package version
+
+        config PKG_USING_BUTTON_V100
+            bool "v1.0.0"
+
+        config PKG_USING_BUTTON_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_BUTTON_VER
+       string
+       default "v1.0.0"    if PKG_USING_BUTTON_V100
+       default "latest"    if PKG_USING_BUTTON_LATEST_VERSION
+
+endif
+

--- a/peripherals/button/package.json
+++ b/peripherals/button/package.json
@@ -1,0 +1,31 @@
+
+{
+    "name": "button",
+    "description": "button drive by C, support single and double click, long press, long press release",
+    "keywords": [
+        "button"
+    ],
+    "site" : [
+    {
+        "version" : "v1.0.0", 
+        "URL" : "https://github.com/jiejieTop/rtt_btn_drv.git", 
+        "filename" : "button-1.0.0.zip",
+        "VER_SHA" : "0cf219a23f3568b82da1c055e2d415eded3b7230"},
+
+    {
+        "version" : "latest",
+        "URL" : "https://github.com/jiejieTop/rtt_btn_drv.git",
+        "filename" : "Null for git package",
+        "VER_SHA" : "master"}
+    ]
+}
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
纯C语言实现的一个按键驱动，可移植性强，支持单双击、连按、连按释放、长按；采用回调处理按键事件（自定义消抖时间），使用只需3步，1：创建按键，2：按键事件与回调处理函数链接映射。然后周期检查按键。