### PR TITLE
【完善】软件包索引信息内容。

### DIFF
--- a/iot/netutils/package.json
+++ b/iot/netutils/package.json
@@ -21,6 +21,7 @@
   "repository": "https://github.com/RT-Thread-packages/netutils",
   "icon": "https://www.rt-thread.org/qa/template/fxiaomi/style/image/logo.png",
   "homepage": "https://github.com/RT-Thread-packages/netutils#readme",
+  "doc": "https://www.rt-thread.org/document/site/rtthread-application-note/packages/netutils/an0018-rtthread-system-netutils/",
   "site": [
     {
       "version": "v1.0.0",

--- a/iot/netutils/package.json
+++ b/iot/netutils/package.json
@@ -1,12 +1,38 @@
 {
-    "name": "netutils",
-    "description": "Networking utilities for RT-Thread",
-    "keywords": [
-        "netutils", "lwip", "net"
-    ],
-    "readme": "Networking utilities for RT-Thread",
-    "site": [
-        { "version": "v1.0.0", "URL": "https://github.com/RT-Thread-packages/netutils/archive/1.0.0.zip", "filename": "netutils-1.0.0.zip", "VER_SHA": "NULL" },
-        { "version": "latest", "URL": "https://github.com/RT-Thread-packages/netutils.git", "filename": "netutils.zip", "VER_SHA": "master" }
-    ]
+  "name": "netutils",
+  "description": "Networking utilities for RT-Thread",
+  "keywords": [
+    "netutils",
+    "lwip",
+    "net",
+    "ntp",
+    "tftp",
+    "iperf",
+    "telnet",
+    "netio",
+    "tcpdump"
+  ],
+  "category": "iot",
+  "author": {
+    "name": "RealThread",
+    "email": "package_team@rt-thread.com"
+  },
+  "license": "GPL-2.0",
+  "repository": "https://github.com/RT-Thread-packages/netutils",
+  "icon": "https://www.rt-thread.org/qa/template/fxiaomi/style/image/logo.png",
+  "homepage": "https://github.com/RT-Thread-packages/netutils#readme",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/RT-Thread-packages/netutils/archive/1.0.0.zip",
+      "filename": "netutils-1.0.0.zip",
+      "VER_SHA": "NULL"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/RT-Thread-packages/netutils.git",
+      "filename": "netutils.zip",
+      "VER_SHA": "master"
+    }
+  ]
 }


### PR DESCRIPTION
- 增加 分类信息（必选），与 env 中菜单类别对应
- 增加 作者信息（必选），包括名字及邮箱
- 增加 许可信息（必选）
- 增加 仓库信息（可选），暂时使用 GitHub 地址
- 增加 图标信息（可选）
- 增加 首页信息（可选），指向用户的软件包首页（可定制非 GitHub 地址）
- 增加 文档信息（可选）

先确定这一个软件包的改法，确认后批量修改其他软件包