### PR TITLE
[iot][netutils] 更新 Kconfig 中 iperf 部分，开启 iperf 默认选择 SAL 和 SAP POSIX

### DIFF
--- a/iot/netutils/Kconfig
+++ b/iot/netutils/Kconfig
@@ -30,6 +30,8 @@ if PKG_USING_NETUTILS
     config PKG_NETUTILS_IPERF
         bool "Enable iperf-liked network performance tool"
         select RT_USING_LIBC
+        select RT_USING_SAL
+        select SAL_USING_POSIX
         default n
 
     config PKG_NETUTILS_NETIO


### PR DESCRIPTION
[iot][netutils] 更新 Kconfig 中 iperf 部分，开启 iperf 默认选择 SAL 和 SAP POSIX

Signed-off-by: MurphyZhao <d2014zjt@163.com>