### PR TITLE
[peripherals/sensors][lsm303agr] 修复双引号不成对的错误

### DIFF
--- a/peripherals/sensors/lsm303agr/Kconfig
+++ b/peripherals/sensors/lsm303agr/Kconfig
@@ -15,7 +15,7 @@ if PKG_USING_LSM303AGR
 		default y
 
     config PKG_USING_LSM303AGR_MAG
-		bool "Enable lsm303agr mag
+		bool "Enable lsm303agr mag"
 		default y
 
     choice


### PR DESCRIPTION
[peripherals/sensors][lsm303agr] 修复双引号不成对的错误

Signed-off-by: MurphyZhao <d2014zjt@163.com>