### PR TITLE
[add] infrared drive frame

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -17,5 +17,6 @@ source "$PKGS_DIR/packages/peripherals/sx12xx/Kconfig"
 source "$PKGS_DIR/packages/peripherals/SignalLed/Kconfig"
 source "$PKGS_DIR/packages/peripherals/wm_libraries/Kconfig"
 source "$PKGS_DIR/packages/peripherals/kendryte-sdk/Kconfig"
+source "$PKGS_DIR/packages/peripherals/infrared/Kconfig"
 
 endmenu

--- a/peripherals/infrared/Kconfig
+++ b/peripherals/infrared/Kconfig
@@ -1,0 +1,72 @@
+
+# Kconfig file for package infrared
+menuconfig PKG_USING_INFRARED
+    bool "infrared : infrared is base on rt-thread pin,hwtimer and pwm."
+    default n
+
+if PKG_USING_INFRARED
+
+    config PKG_INFRARED_PATH
+        string
+        default "/packages/peripherals/infrared"
+
+    menu "Select infrared decoder"
+        config INFRARED_NEC_DECODER
+            bool "enable nec decoder"
+            default n
+    endmenu
+
+    config INFRARED_SEND
+        bool "Enable infrared send"
+        default n
+        if INFRARED_SEND
+            config INFRARED_SEND_PWM
+                string "infrared pwm dev name"
+                default "pwm4"
+
+            config INFRARED_PWM_DEV_CHANNEL
+                int "infrared pwm channel"
+                default 3
+
+            config INFRARED_SEND_HWTIMER
+                string "infrared send hwtimer dev name"
+                default "timer15"
+
+            config INFRARED_MAX_SEND_SIZE
+                int "infrared max send size"
+                default 1000
+        endif
+
+    config INFRARED_RECEIVE
+        bool "Enable infrared receive"
+        default n
+        if INFRARED_RECEIVE
+            config INFRARED_RECEIVE_PIN
+                int "infrared receive pin number"
+                default 17
+        
+            config INFRARED_RECEIVE_HWTIMER
+                string "infrared receive hwtimer dev name"
+                default "timer16"
+        endif
+
+    choice
+        prompt "Version"
+        default PKG_USING_INFRARED_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_INFRARED_V100
+            bool "v1.0.0"
+
+        config PKG_USING_INFRARED_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_INFRARED_VER
+       string
+       default "v1.0.0"    if PKG_USING_INFRARED_V100
+       default "latest"    if PKG_USING_INFRARED_LATEST_VERSION
+
+endif
+

--- a/peripherals/infrared/package.json
+++ b/peripherals/infrared/package.json
@@ -19,9 +19,9 @@
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://infrared-1.0.0.zip",
-      "filename": "infrared-1.0.0.zip",
-      "VER_SHA": "fill in the git version SHA value"
+      "URL": "https://codeload.github.com/balanceTWK/Infrared_frame/zip/1.0.0",
+      "filename": "Infrared_frame-1.0.0.zip",
+      "VER_SHA": "NULL"
     },
     {
       "version": "latest",

--- a/peripherals/infrared/package.json
+++ b/peripherals/infrared/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "infrared",
+  "description": "Infrared framework based on rt-thread's pin,pwm and hwtimer driver.",
+  "description_zh": "基于 rt-thread 的 pin,pwm 和 hwtimer 驱动的红外框架。",  
+  "keywords": [
+    "infrared",
+    "红外"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "BalanceTWK",
+    "email": "balanceTWK@gmail.com"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/balanceTWK/Infrared_frame.git",
+  "icon": "unknown",
+  "homepage": "unknown",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://infrared-1.0.0.zip",
+      "filename": "infrared-1.0.0.zip",
+      "VER_SHA": "fill in the git version SHA value"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/balanceTWK/Infrared_frame.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
基于  rt-thread `pin` 、 `pwm` 、 `hwtimer` 的红外驱动。

## 相关测试情况
  1. 在正点原子 L4 IoT board 测试通过。
  2. 在正点原子 F407 测试通过。

![image](https://user-images.githubusercontent.com/30776697/55220016-38c07680-5241-11e9-9a38-749c6b874e26.png)
