### PR TITLE
[new package] rosserial

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -18,5 +18,6 @@ source "$PKGS_DIR/packages/peripherals/SignalLed/Kconfig"
 source "$PKGS_DIR/packages/peripherals/wm_libraries/Kconfig"
 source "$PKGS_DIR/packages/peripherals/kendryte-sdk/Kconfig"
 source "$PKGS_DIR/packages/peripherals/infrared/Kconfig"
+source "$PKGS_DIR/packages/peripherals/rosserial/Kconfig"
 
 endmenu

--- a/peripherals/rosserial/Kconfig
+++ b/peripherals/rosserial/Kconfig
@@ -14,10 +14,15 @@ if PKG_USING_ROSSERIAL
         config ROSSERIAL_USING_HELLO_WORLD_UART
             bool "Hello World  : hello world example using UART"
             select RT_USING_SERIAL
-            select RT_USING_UART2
             help
                 Hello World example using UART
             default n
+
+        if ROSSERIAL_USING_HELLO_WORLD_UART
+            config ROSSERIAL_UART_NAME
+            string "serial device name"
+            default "uart2"
+        endif
     endmenu
 
     choice

--- a/peripherals/rosserial/Kconfig
+++ b/peripherals/rosserial/Kconfig
@@ -1,0 +1,37 @@
+
+# Kconfig file for package ROSSERIAL
+menuconfig PKG_USING_ROSSERIAL
+    bool "rosserial: a protocol for Robots Operating System (ROS)"
+    default n
+
+if PKG_USING_ROSSERIAL
+
+    config PKG_ROSSERIAL_PATH
+        string
+        default "/packages/peripherals/rosserial"
+
+    menu "roserial examples"
+        config ROSSERIAL_USING_HELLO_WORLD_UART
+            bool "Hello World  : hello world example using UART"
+            select RT_USING_SERIAL
+            select RT_USING_UART2
+            help
+                Hello World example using UART
+            default n
+    endmenu
+
+    choice
+        prompt "Version"
+        default PKG_USING_ROSSERIAL_LATEST_VERSION
+        help
+            Select the package version
+        config PKG_USING_ROSSERIAL_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_ROSSERIAL_VER
+       string
+       default "latest"    if PKG_USING_ROSSERIAL_LATEST_VERSION
+
+endif
+

--- a/peripherals/rosserial/package.json
+++ b/peripherals/rosserial/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "rosserial",
+  "description": "rosserial protocol for Robots Operating System (ROS) on rt-thread",
+  "description_zh": "机器人操作系统(ROS) 软件包 rosserial 在 RT-Thread 的移植库",
+  "keywords": [
+    "rosserial",
+    "ROS"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@hust.edu.cn"
+  },
+  "license": "BSD",
+  "repository": "https://github.com/wuhanstudio/rt-rosserial",
+  "homepage": "https://github.com/wuhanstudio/rt-rosserial#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/rt-rosserial.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
rosserial 是机器人操作系统(ROS)的一个通讯协议，最近把它移植到了 rt-thread 。

[ROS ](http://www.ros.org/)(Robots Operating System) 最早是斯坦福大学的一个软件框架，现在不管是工业机器人，还是娱乐用的机器人都运行着ROS。为了保证稳定性，机器人通常是由不同节点组成的，节点间的通信就是靠 rosserial 协议实现的。

rt-thread 支持的处理器非常多，把 rosserial 移植到 rt-thread后，希望今后机器人节点说不定就是 ROS + RT-Thread 搭配了。大量高性能计算用主节点 Ubuntu 跑 ROS，外设节点用 RT-Thread 采集传感器数据，感觉这样搭配还是挺不错的 ;)
