### PR TITLE
增加BH1750FVI传感器驱动软件包

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -20,4 +20,5 @@ source "$PKGS_DIR/packages/peripherals/kendryte-sdk/Kconfig"
 source "$PKGS_DIR/packages/peripherals/infrared/Kconfig"
 source "$PKGS_DIR/packages/peripherals/rosserial/Kconfig"
 source "$PKGS_DIR/packages/peripherals/at24cxx/Kconfig"
+source "$PKGS_DIR/packages/peripherals/bh1750/Kconfig"
 endmenu

--- a/peripherals/bh1750/Kconfig
+++ b/peripherals/bh1750/Kconfig
@@ -1,0 +1,51 @@
+
+# Kconfig file for package BH1750FVI
+menuconfig PKG_USING_BH1750
+    bool "BH1750FVI: Ambient Light Sensor IC BH1750FVI driver library"
+    default n
+
+if PKG_USING_BH1750
+
+    config PKG_BH1750_PATH
+        string
+        default "/packages/peripherals/bh1750"
+
+    config BH1750_USING_SOFT_FILTER
+        bool "Enable average filter by software"
+        default n
+        help
+            "It will automatic sample sensor's data by average filter thread."
+            
+    if BH1750_USING_SOFT_FILTER  
+    
+        config BH1750_AVERAGE_TIMES
+            int "The number of averaging"
+            default 10  
+            help
+                "When selected filter function, it will be the number you will add and divide amount."
+                
+        config BH1750_SAMPLE_PERIOD
+            int "Peroid of sampling data(unit ms)"
+            default 1000 
+            help
+                "When selected filter function, it will be the period you will sample. The unit of the period is millisecond."
+    endif        
+       
+
+    choice
+        prompt "Version"
+        default PKG_USING_BH1750_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_BH1750_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_BH1750_VER
+       string
+       default "v1.0.0"    if PKG_USING_BH1750_V100
+       default "latest"    if PKG_USING_BH1750_LATEST_VERSION
+
+endif
+

--- a/peripherals/bh1750/package.json
+++ b/peripherals/bh1750/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bh1750",
+  "description": "bh1750: Ambient Light Sensor IC BH1750FVI driver library",
+  "description_zh": "数字光照强度传感器IC BH1750FVI 驱动软件包", 
+  "keywords": [
+    "bh1750"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "Sanjay_Wu",
+    "email": "sanjaywu@yeah.net"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/sanjaywu/bh1750",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/sanjaywu/bh1750.git",
+      "filename": "bh1750.zip",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
Hi， 我添加了BH1750FVI数字光照强度传感器IC的驱动软件包，已经测试通，软件包放在我的GitHub：https://github.com/sanjaywu/bh1750，请审核，有如问题请指出指正，我完善修改，谢谢！