### PR TITLE
增加基于sensor框架的BH1750FVI驱动软件包

### DIFF
--- a/peripherals/sensors/Kconfig
+++ b/peripherals/sensors/Kconfig
@@ -17,5 +17,6 @@ menuconfig PKG_USING_SENSORS_DRIVERS
         source "$PKGS_DIR/packages/peripherals/sensors/da270/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/df220/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/hshcal001/Kconfig"
-
+		source "$PKGS_DIR/packages/peripherals/sensors/bh1750/Kconfig"
+		
     endif

--- a/peripherals/sensors/Kconfig
+++ b/peripherals/sensors/Kconfig
@@ -16,7 +16,7 @@ menuconfig PKG_USING_SENSORS_DRIVERS
         source "$PKGS_DIR/packages/peripherals/sensors/ms5611/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/da270/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/df220/Kconfig"
-        source "$PKGS_DIR/packages/peripherals/sensors/hshcal001/Kconfig"
-		source "$PKGS_DIR/packages/peripherals/sensors/bh1750/Kconfig"
+		source "$PKGS_DIR/packages/peripherals/sensors/hshcal001/Kconfig"
+        source "$PKGS_DIR/packages/peripherals/sensors/bh1750/Kconfig"
 		
     endif

--- a/peripherals/sensors/bh1750/Kconfig
+++ b/peripherals/sensors/bh1750/Kconfig
@@ -1,0 +1,29 @@
+
+# Kconfig file for package BH1750FVI
+menuconfig PKG_USING_BH1750
+    bool "bh1750 sensor driver package, support: ambient light."
+    default n
+
+if PKG_USING_BH1750
+
+    config PKG_BH1750_PATH
+        string
+        default "/packages/peripherals/sensors/bh1750"
+
+    choice
+        prompt "Version"
+        default PKG_USING_BH1750_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_BH1750_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_BH1750_VER
+       string
+       default "v1.0.0"    if PKG_USING_BH1750_V100
+       default "latest"    if PKG_USING_BH1750_LATEST_VERSION
+
+endif
+

--- a/peripherals/sensors/bh1750/package.json
+++ b/peripherals/sensors/bh1750/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bh1750",
+  "description": "bh1750 sensor driver package, support: temperature, humidity.",
+  "description_zh":"bh1750 传感器驱动包，支持：环境光照强度.",
+  "keywords": [
+    "bh1750"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "Sanjay_Wu",
+    "email": "sanjaywu@yeah.net"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/sanjaywu/BH1750FVI",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/sanjaywu/BH1750FVI.git",
+      "filename": "BH1750FVI.zip",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
Hi Armink，新做了BH1750FVI环境光照强度软件包，新驱动软件包是基于sensor框架，已测试成功，请审核，如有问题请指正指出，谢谢！软件包：[https://github.com/sanjaywu/BH1750FVI](url)