### PR TITLE
修改宏开关，使同时支持旧版本BH1750FVI驱动和基于sensor框架的BH1750FVI驱动

### DIFF
--- a/peripherals/sensors/bh1750/Kconfig
+++ b/peripherals/sensors/bh1750/Kconfig
@@ -1,29 +1,28 @@
-
 # Kconfig file for package BH1750FVI
-menuconfig PKG_USING_BH1750
+menuconfig PKG_USING_SENSOR_BH1750
     bool "bh1750 sensor driver package, support: ambient light."
     default n
 
-if PKG_USING_BH1750
+if PKG_USING_SENSOR_BH1750
 
-    config PKG_BH1750_PATH
+    config PKG_SENSOR_BH1750_PATH
         string
         default "/packages/peripherals/sensors/bh1750"
 
     choice
         prompt "Version"
-        default PKG_USING_BH1750_LATEST_VERSION
+        default PKG_USING_SENSOR_BH1750_LATEST_VERSION
         help
             Select the package version
 
-        config PKG_USING_BH1750_LATEST_VERSION
+        config PKG_USING_SENSOR_BH1750_LATEST_VERSION
             bool "latest"
     endchoice
 
-    config PKG_BH1750_VER
+    config PKG_SENSOR_BH1750_VER
        string
-       default "v1.0.0"    if PKG_USING_BH1750_V100
-       default "latest"    if PKG_USING_BH1750_LATEST_VERSION
+       default "v1.0.0"    if PKG_USING_SENSOR_BH1750_V100
+       default "latest"    if PKG_USING_SENSOR_BH1750_LATEST_VERSION
 
 endif
 


### PR DESCRIPTION
Hi Armink & Guo，已经修改同时兼容支持两个版本的软件包，请审核，如有问题，请指正指出，谢谢！