### PR TITLE
兼容旧版本BH1750FVI驱动软件和基于sensor框架的BH1750FVI驱动软件包

### DIFF
--- a/peripherals/sensors/bh1750/Kconfig
+++ b/peripherals/sensors/bh1750/Kconfig
@@ -1,4 +1,4 @@
-# Kconfig file for package BH1750FVI
+# Kconfig file for package BH1750FVI seneor
 menuconfig PKG_USING_SENSOR_BH1750
     bool "bh1750 sensor driver package, support: ambient light."
     default n

--- a/peripherals/sensors/bh1750/Kconfig
+++ b/peripherals/sensors/bh1750/Kconfig
@@ -1,29 +1,28 @@
-
 # Kconfig file for package BH1750FVI
-menuconfig PKG_USING_BH1750
+menuconfig PKG_USING_SENSOR_BH1750
     bool "bh1750 sensor driver package, support: ambient light."
     default n
 
-if PKG_USING_BH1750
+if PKG_USING_SENSOR_BH1750
 
-    config PKG_BH1750_PATH
+    config PKG_SENSOR_BH1750_PATH
         string
         default "/packages/peripherals/sensors/bh1750"
 
     choice
         prompt "Version"
-        default PKG_USING_BH1750_LATEST_VERSION
+        default PKG_USING_SENSOR_BH1750_LATEST_VERSION
         help
             Select the package version
 
-        config PKG_USING_BH1750_LATEST_VERSION
+        config PKG_USING_SENSOR_BH1750_LATEST_VERSION
             bool "latest"
     endchoice
 
-    config PKG_BH1750_VER
+    config PKG_SENSOR_BH1750_VER
        string
-       default "v1.0.0"    if PKG_USING_BH1750_V100
-       default "latest"    if PKG_USING_BH1750_LATEST_VERSION
+       default "v1.0.0"    if PKG_USING_SENSOR_BH1750_V100
+       default "latest"    if PKG_USING_SENSOR_BH1750_LATEST_VERSION
 
 endif
 


### PR DESCRIPTION
Hi Guo，已经兼容旧版本BH1750FVI驱动软件和基于sensor框架的BH1750FVI驱动软件包，请审核，如有问题请指正指出，谢谢！