### PR TITLE
fix：compile error: 'GUIENGINE_NAME_MAX' undeclared here

### DIFF
--- a/system/gui_engine/Kconfig
+++ b/system/gui_engine/Kconfig
@@ -134,5 +134,9 @@ config GUIENGINE_USING_DEMO
     bool "Enable the example of GUI Engine"
     default n
 
+config GUIENGINE_NAME_MAX
+    int "The maximal size of name in GUI Engine"
+    default 16
+
 endif
 


### PR DESCRIPTION
compile error: 'GUIENGINE_NAME_MAX' undeclared here (not in a function)