### PR TITLE
【更新】mbedtls 软件包索引

### DIFF
--- a/security/mbedtls/Kconfig
+++ b/security/mbedtls/Kconfig
@@ -123,22 +123,10 @@ if PKG_USING_MBEDTLS
             bool "latest"
     endchoice
 
-    if PKG_USING_MBEDTLS_V270
-        config PKG_MBEDTLS_VER
+    config PKG_MBEDTLS_VER
         string
-        default "v2.7.0"
-    endif
-
-    if PKG_USING_MBEDTLS_V260
-        config PKG_MBEDTLS_VER
-        string
-        default "v2.6.0"
-    endif
-
-    if PKG_USING_MBEDTLS_LATEST_VERSION
-       config PKG_MBEDTLS_VER
-       string
-       default "latest"
-    endif
+        default "latest"    if PKG_USING_MBEDTLS_LATEST_VERSION
+        default "v2.7.0"    if PKG_USING_MBEDTLS_V270
+        default "v2.6.0"    if PKG_USING_MBEDTLS_V260
 
 endif

--- a/security/mbedtls/Kconfig
+++ b/security/mbedtls/Kconfig
@@ -89,7 +89,17 @@ if PKG_USING_MBEDTLS
         bool "Enable a mbedtls client example"
         select PKG_USING_MBEDTLS_DIGICERT_ROOT_CA
         default n
-        
+
+    if PKG_USING_MBEDTLS_V270
+        config MBEDTLS_MPI_MAX_SIZE
+            int "Maximum number of bytes for usable MPIs"
+            default 1024
+
+        config MBEDTLS_CTR_DRBG_KEYSIZE
+            int "The key size used by the cipher"
+            default 32
+    endif
+
     config PKG_USING_MBEDTLS_DEBUG
         bool "Enable Debug log output"
         default n
@@ -103,13 +113,21 @@ if PKG_USING_MBEDTLS
         help
             Select the mbedtls version
 
+        config PKG_USING_MBEDTLS_V270
+            bool "v2.7.0"
+
         config PKG_USING_MBEDTLS_V260
             bool "v2.6.0"
 
         config PKG_USING_MBEDTLS_LATEST_VERSION
             bool "latest"
-
     endchoice
+
+    if PKG_USING_MBEDTLS_V270
+        config PKG_MBEDTLS_VER
+        string
+        default "v2.7.0"
+    endif
 
     if PKG_USING_MBEDTLS_V260
         config PKG_MBEDTLS_VER

--- a/security/mbedtls/Kconfig
+++ b/security/mbedtls/Kconfig
@@ -90,7 +90,7 @@ if PKG_USING_MBEDTLS
         select PKG_USING_MBEDTLS_DIGICERT_ROOT_CA
         default n
 
-    if PKG_USING_MBEDTLS_V270
+    if PKG_USING_MBEDTLS_V2710
         config MBEDTLS_MPI_MAX_SIZE
             int "Maximum number of bytes for usable MPIs"
             default 1024
@@ -113,8 +113,11 @@ if PKG_USING_MBEDTLS
         help
             Select the mbedtls version
 
-        config PKG_USING_MBEDTLS_V270
-            bool "v2.7.0"
+        config PKG_USING_MBEDTLS_V2710
+            bool "v2.7.10"
+
+        config PKG_USING_MBEDTLS_V261
+            bool "v2.6.1"
 
         config PKG_USING_MBEDTLS_V260
             bool "v2.6.0"
@@ -126,7 +129,8 @@ if PKG_USING_MBEDTLS
     config PKG_MBEDTLS_VER
         string
         default "latest"    if PKG_USING_MBEDTLS_LATEST_VERSION
-        default "v2.7.0"    if PKG_USING_MBEDTLS_V270
+        default "v2.7.10"   if PKG_USING_MBEDTLS_V2710
+        default "v2.6.1"    if PKG_USING_MBEDTLS_V261
         default "v2.6.0"    if PKG_USING_MBEDTLS_V260
 
 endif

--- a/security/mbedtls/package.json
+++ b/security/mbedtls/package.json
@@ -18,6 +18,11 @@
   "readme": "An open source, portable, easy to use, readable and flexible SSL library",
   "site": [
     {
+      "version": "v2.7.0",
+      "URL": "https://github.com/RT-Thread-packages/mbedtls/archive/2.7.0.zip",
+      "filename": "mbedtls-2.7.0.zip"
+    },
+    {
       "version": "v2.6.0",
       "URL": "https://github.com/RT-Thread-packages/mbedtls/archive/2.6.0.zip",
       "filename": "mbedtls-2.6.0.zip"

--- a/security/mbedtls/package.json
+++ b/security/mbedtls/package.json
@@ -18,9 +18,14 @@
   "readme": "An open source, portable, easy to use, readable and flexible SSL library",
   "site": [
     {
-      "version": "v2.7.0",
-      "URL": "https://github.com/RT-Thread-packages/mbedtls/archive/2.7.0.zip",
-      "filename": "mbedtls-2.7.0.zip"
+      "version": "v2.7.10",
+      "URL": "https://github.com/RT-Thread-packages/mbedtls/archive/2.7.10.zip",
+      "filename": "mbedtls-2.7.10.zip"
+    },
+    {
+      "version": "v2.6.1",
+      "URL": "https://github.com/RT-Thread-packages/mbedtls/archive/2.6.1.zip",
+      "filename": "mbedtls-2.6.1.zip"
     },
     {
       "version": "v2.6.0",


### PR DESCRIPTION
增加了一些配置

- 密钥长度。针对仅支持 128 位硬件加解密的芯片
- 大数最大长度。

增加 2.7.10 版本
