### PR TITLE
Upstream libann

### DIFF
--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -18,5 +18,6 @@ source "$PKGS_DIR/packages/misc/samples/Kconfig"
 source "$PKGS_DIR/packages/misc/hello/Kconfig"
 source "$PKGS_DIR/packages/misc/vi/Kconfig"
 source "$PKGS_DIR/packages/misc/nnom/Kconfig"
+source "$PKGS_DIR/packages/misc/libann/Kconfig"
 
 endmenu

--- a/misc/libann/Kconfig
+++ b/misc/libann/Kconfig
@@ -10,6 +10,18 @@ if PKG_USING_LIBANN
         string
         default "/packages/misc/libann"
 
+    config LIBANN_USING_IRIS_TRAIN_AND_PREDICT
+        bool "Iris train model and predict example"
+        help
+            Load Iris dataset, train, predict, and save model.
+        default n
+
+    config LIBANN_USING_IRIS_LOAD_AND_PREDICT
+        bool "Iris load model and predict example"
+        help
+            Load Iris dataset, load model, predict, and save model.
+        default n
+
     choice
         prompt "Version"
         default PKG_USING_LIBANN_LATEST_VERSION

--- a/misc/libann/Kconfig
+++ b/misc/libann/Kconfig
@@ -1,0 +1,31 @@
+
+# Kconfig file for package libann
+menuconfig PKG_USING_LIBANN
+    bool "libann: a light-weight ANN library, capable of training, saving and loading models."
+    default n
+
+if PKG_USING_LIBANN
+
+    config PKG_LIBANN_PATH
+        string
+        default "/packages/misc/libann"
+
+    choice
+        prompt "Version"
+        default PKG_USING_LIBANN_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_LIBANN_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_LIBANN_VER
+       string
+       default "latest"    if PKG_USING_LIBANN_LATEST_VERSION
+
+    config PKG_LIBANN_VER_NUM
+        hex
+        default 0x99999 if PKG_USING_LIBANN_LATEST_VERSION
+
+endif

--- a/misc/libann/package.json
+++ b/misc/libann/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "libann",
+  "description": "A light-weight ANN library, capable of training, saving and loading models.",
+  "description_zh": "轻量级 ANN 库，可以训练，保存和导入模型",
+  "keywords": [
+    "ANN"
+  ],
+  "category": "misc",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@hust.edu.cn"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/wuhanstudio/rt-libann",
+  "homepage": "https://github.com/wuhanstudio/rt-libann#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/rt-libann.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
添加轻量级的 ANN 软件包，可以在 stm32 上训练 ANN 模型。

以经典的 Iris 数据集为例，使用一层隐藏层、隐藏层节点为4，训练 150 个样本，迭代 500 次，在 STM32L475VET6 上训练时间为 24 秒，预测时间为 22 毫秒，预测精度为 96.0%。

![iris_train_and_predict](https://user-images.githubusercontent.com/15157070/59840692-7129a980-9385-11e9-9446-24ac1cf74f9c.png)
