### PR TITLE
[i2c-tools] Use lowercase

### DIFF
--- a/peripherals/i2c_tools/Kconfig
+++ b/peripherals/i2c_tools/Kconfig
@@ -11,7 +11,7 @@ if PKG_USING_I2C_TOOLS
 
     config PKG_I2C_TOOLS_PATH
         string
-        default "/packages/peripherals/I2C_TOOLS"
+        default "/packages/peripherals/i2c_tools"
 
     config I2C_TOOLS_USE_SW_I2C
         bool "Use sofware I2C"


### PR DESCRIPTION
软件包路径不小心写成了大写，windows 不区分大小写一直没发现