### PR TITLE
Upstream onnx add example

### DIFF
--- a/iot/onnx-parser/Kconfig
+++ b/iot/onnx-parser/Kconfig
@@ -11,6 +11,12 @@ if PKG_USING_ONNX_PARSER
         string
         default "/packages/iot/onnx-parser"
 
+    config ONNX_PARSER_USING_RAM_EXAMPLE
+        bool "onnx-parser example: decode onnx model in RAM"
+        help
+            onnx-parser example: decode in RAM
+        default n
+
     config ONNX_PARSER_USING_EXAMPLE
         bool "onnx-parser example: decode onnx model from file"
         help

--- a/iot/onnx-parser/Kconfig
+++ b/iot/onnx-parser/Kconfig
@@ -1,7 +1,8 @@
 
 # Kconfig file for package onnx-parser
 menuconfig PKG_USING_ONNX_PARSER
-	select PKG_USING_PROTOBUF_C
+    select PKG_USING_PROTOBUF_C
+    select RT_USING_LIBC
     bool "onnx-parser: Open Neural Network Exchange model parser on RT-Thread"
     default n
 


### PR DESCRIPTION
- 软件包默认选中 libc：文件操作从 rt-thread api 切为 POSIX C
- 添加解析 C 数组模型的例子：xxd -i mnist.onnx > mnist_onnx.c