### PR TITLE
[new][misc] Add package vt100

### DIFF
--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -21,5 +21,6 @@ source "$PKGS_DIR/packages/misc/vi/Kconfig"
 source "$PKGS_DIR/packages/misc/nnom/Kconfig"
 source "$PKGS_DIR/packages/misc/libann/Kconfig"
 source "$PKGS_DIR/packages/misc/elapack/Kconfig"
+source "$PKGS_DIR/packages/misc/vt100/Kconfig"
 
 endmenu

--- a/misc/vt100/Kconfig
+++ b/misc/vt100/Kconfig
@@ -1,0 +1,38 @@
+
+# Kconfig file for package vt100
+menuconfig PKG_USING_VT100
+    bool "vt100: iridescent drawing library on MSH"
+    select RT_USING_LIBC
+    default n
+
+if PKG_USING_VT100
+
+    config PKG_VT100_PATH
+        string
+        default "/packages/misc/vt100"
+
+    config VT100_USING_MONITOR
+        bool "RT-Thread monitor example"
+        help
+            RT-Thread monitor.
+        default n
+
+    choice
+        prompt "Version"
+        default PKG_USING_VT100_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_VT100_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_VT100_VER
+       string
+       default "latest"    if PKG_USING_VT100_LATEST_VERSION
+
+    config PKG_VT100_VER_NUM
+        hex
+        default 0x99999 if PKG_USING_VT100_LATEST_VERSION
+
+endif

--- a/misc/vt100/Kconfig
+++ b/misc/vt100/Kconfig
@@ -12,9 +12,21 @@ if PKG_USING_VT100
         default "/packages/misc/vt100"
 
     config VT100_USING_MONITOR
-        bool "RT-Thread monitor example"
+        bool "Monitor: RT-Thread monitor example"
         help
             RT-Thread monitor.
+        default n
+
+    config VT100_USING_COLOR
+        bool "Color: Draw different colors and boxes"
+        help
+            Color: Draw different colors and boxes
+        default n
+
+    config VT100_USING_SL
+        bool "Animation: a funny rushing train"
+        help
+            Animation: a funny rushing train
         default n
 
     choice

--- a/misc/vt100/package.json
+++ b/misc/vt100/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vt100",
+  "description": "iridescent drawing library on MSH",
+  "description_zh": "串口终端绘图库，可以在 msh 下画图",
+  "keywords": [
+    "vt100",
+    "msh"
+  ],
+  "category": "misc",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@hust.edu.cn"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/wuhanstudio/vt100",
+  "homepage": "https://github.com/wuhanstudio/vt100#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/vt100.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
RT-Thread 的终端 msh 一直是一个非常受大家欢迎的组件，但是终端只能打印基本的字符未免有些单调了，于是我封装了 ANSI Escape 标准，这样就可以在 msh 里实现更加丰富的图形界面了，例如动画和游戏开发。

### 奔跑的小火车

![sl](https://user-images.githubusercontent.com/15157070/63638719-8ccf6a00-c6be-11e9-8e2c-4439194c42ed.gif)

小火车还有不同类型

![sl_c](https://user-images.githubusercontent.com/15157070/63638720-9062f100-c6be-11e9-8b34-2c57b59b8289.png)

### 实时控制台

![monitor](https://user-images.githubusercontent.com/15157070/63638724-948f0e80-c6be-11e9-9c5b-ad6c73e750a3.png)

### 绘制色条矩形

![color](https://user-images.githubusercontent.com/15157070/63638725-98229580-c6be-11e9-9b30-57080a5a4ce0.png)
