### PR TITLE
1.Kconfig增加软时钟库依赖

### DIFF
--- a/iot/iot_cloud/jiot-c-sdk/Kconfig
+++ b/iot/iot_cloud/jiot-c-sdk/Kconfig
@@ -3,6 +3,7 @@
 menuconfig PKG_USING_JIOT-C-SDK
     bool "jiot-c-sdk: JIGUANG IoT Cloud Client SDK for RT_Thread"
 	select RT_USING_RTC
+	select RT_USING_SOFT_RTC
 	select RT_USING_SAL
 	select SAL_USING_POSIX
     default n


### PR DESCRIPTION
由于sdk中依赖了软时钟驱动来实现定时，等待等操作，因此需要添加此依赖