### PR TITLE
[misc][ulapack] new package ulapack

### DIFF
--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -23,5 +23,6 @@ source "$PKGS_DIR/packages/misc/libann/Kconfig"
 source "$PKGS_DIR/packages/misc/elapack/Kconfig"
 source "$PKGS_DIR/packages/misc/armv7m_dwt/Kconfig"
 source "$PKGS_DIR/packages/misc/vt100/Kconfig"
+source "$PKGS_DIR/packages/misc/ulapack/Kconfig"
 
 endmenu

--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -24,5 +24,6 @@ source "$PKGS_DIR/packages/misc/elapack/Kconfig"
 source "$PKGS_DIR/packages/misc/armv7m_dwt/Kconfig"
 source "$PKGS_DIR/packages/misc/vt100/Kconfig"
 source "$PKGS_DIR/packages/misc/ulapack/Kconfig"
+source "$PKGS_DIR/packages/misc/ukal/Kconfig"
 
 endmenu

--- a/misc/ukal/Kconfig
+++ b/misc/ukal/Kconfig
@@ -34,6 +34,16 @@ if PKG_USING_UKAL
         comment "Static memory allocation selected from ulapack"
     endif
 
+    if ULAPACK_USE_STATIC_ALLOC
+        config ULAPACK_MAX_MATRIX_N_ROWS
+            int "Matrix maximum number of rows"
+            default "20"
+
+        config ULAPACK_MAX_MATRIX_N_COLS
+            int "Matrix maximum number of columns"
+            default "20"
+    endif
+
     choice
         prompt "Version"
         default PKG_USING_UKAL_LATEST_VERSION

--- a/misc/ukal/Kconfig
+++ b/misc/ukal/Kconfig
@@ -1,6 +1,8 @@
 
 # Kconfig file for package ukal
 menuconfig PKG_USING_UKAL
+    select RT_USING_LIBC
+    select PKG_USING_ULAPACK
     bool "ukal: Kalman filter based on ulapack."
     default n
 

--- a/misc/ukal/Kconfig
+++ b/misc/ukal/Kconfig
@@ -26,6 +26,14 @@ if PKG_USING_UKAL
             Extended kalman filter example
         default n
 
+    if ULAPACK_USE_DYNAMIC_ALLOC
+        comment "Dymamic memory allocation selected from ulapack"
+    endif
+
+    if ULAPACK_USE_STATIC_ALLOC
+        comment "Static memory allocation selected from ulapack"
+    endif
+
     choice
         prompt "Version"
         default PKG_USING_UKAL_LATEST_VERSION

--- a/misc/ukal/Kconfig
+++ b/misc/ukal/Kconfig
@@ -12,6 +12,14 @@ if PKG_USING_UKAL
         string
         default "/packages/misc/ukal"
 
+    config UKAL_MAX_STATE_VECTOR_SIZE
+        int "Maximum state vcector size"
+        default "5"
+
+    config UKAL_MAX_MEASUREMENT_VECTOR_SIZE
+        int "Maximum state vector size"
+        default "5"
+
     config UKAL_USING_EKAL
         bool "Extended kalman filter example"
         help

--- a/misc/ukal/Kconfig
+++ b/misc/ukal/Kconfig
@@ -10,6 +10,12 @@ if PKG_USING_UKAL
         string
         default "/packages/misc/ukal"
 
+    config UKAL_USING_EKAL
+        bool "Extended kalman filter example"
+        help
+            Extended kalman filter example
+        default n
+
     choice
         prompt "Version"
         default PKG_USING_UKAL_LATEST_VERSION

--- a/misc/ukal/Kconfig
+++ b/misc/ukal/Kconfig
@@ -21,9 +21,9 @@ if PKG_USING_UKAL
         default "5"
 
     config UKAL_USING_EKAL
-        bool "Extended kalman filter example"
+        bool "Extended Kalman filter example"
         help
-            Extended kalman filter example
+            Extended Kalman filter example
         default n
 
     if ULAPACK_USE_DYNAMIC_ALLOC

--- a/misc/ukal/Kconfig
+++ b/misc/ukal/Kconfig
@@ -1,0 +1,30 @@
+
+# Kconfig file for package ukal
+menuconfig PKG_USING_UKAL
+    bool "ukal: Kalman filter based on ulapack."
+    default n
+
+if PKG_USING_UKAL
+
+    config PKG_UKAL_PATH
+        string
+        default "/packages/misc/ukal"
+
+    choice
+        prompt "Version"
+        default PKG_USING_UKAL_LATEST_VERSION
+        help
+            Select the package version
+        config PKG_USING_UKAL_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_UKAL_VER
+       string
+       default "latest"    if PKG_USING_UKAL_LATEST_VERSION
+
+    config PKG_UKAL_VER_NUM
+        hex
+        default 0x99999 if PKG_USING_UKAL_LATEST_VERSION
+
+endif

--- a/misc/ukal/package.json
+++ b/misc/ukal/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ukal",
+  "description": "Kalman filter based on ulapack",
+  "description_zh": "卡尔曼滤波算法",
+  "keywords": [
+    "Linear Algebra",
+    "lapack"
+  ],
+  "category": "misc",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@hust.edu.cn"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/wuhanstudio/ukal",
+  "homepage": "https://github.com/wuhanstudio/ukal#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/ukal.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}

--- a/misc/ulapack/Kconfig
+++ b/misc/ulapack/Kconfig
@@ -30,9 +30,9 @@ if PKG_USING_ULAPACK
         default n
 
     config ULAPACK_USING_POLYFIT
-        bool "polynomial regression example"
+        bool "Polynomial regression example"
         help
-            polynomial regression example
+            Polynomial regression example
         default n
 
     choice

--- a/misc/ulapack/Kconfig
+++ b/misc/ulapack/Kconfig
@@ -11,6 +11,12 @@ if PKG_USING_ULAPACK
         string
         default "/packages/misc/ulapack"
 
+    config ULAPACK_USING_PCA
+        bool "Principal components analysis example"
+        help
+            Principal components analysis example
+        default n
+
     choice
         prompt "Version"
         default PKG_USING_ULAPACK_LATEST_VERSION

--- a/misc/ulapack/Kconfig
+++ b/misc/ulapack/Kconfig
@@ -1,0 +1,35 @@
+
+# Kconfig file for package ulapack
+menuconfig PKG_USING_ULAPACK
+    select RT_USING_LIBC
+    bool "ulapack: linear algebra library for embedded devices."
+    default n
+
+if PKG_USING_ULAPACK
+
+    config PKG_ULAPACK_PATH
+        string
+        default "/packages/misc/ulapack"
+
+    choice
+        prompt "Version"
+        default PKG_USING_ULAPACK_LATEST_VERSION
+        help
+            Select the package version
+        config PKG_USING_ULAPACK_V100
+            bool "v1.0.0"
+        config PKG_USING_ULAPACK_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_ULAPACK_VER
+       string
+       default "v1.0.0"    if PKG_USING_ULAPACK_V100
+       default "latest"    if PKG_USING_ULAPACK_LATEST_VERSION
+
+    config PKG_ULAPACK_VER_NUM
+        hex
+        default 0x10000 if PKG_USING_ULAPACK_V100
+        default 0x99999 if PKG_USING_ULAPACK_LATEST_VERSION
+
+endif

--- a/misc/ulapack/Kconfig
+++ b/misc/ulapack/Kconfig
@@ -40,20 +40,16 @@ if PKG_USING_ULAPACK
         default PKG_USING_ULAPACK_LATEST_VERSION
         help
             Select the package version
-        config PKG_USING_ULAPACK_V100
-            bool "v1.0.0"
         config PKG_USING_ULAPACK_LATEST_VERSION
             bool "latest"
     endchoice
 
     config PKG_ULAPACK_VER
        string
-       default "v1.0.0"    if PKG_USING_ULAPACK_V100
        default "latest"    if PKG_USING_ULAPACK_LATEST_VERSION
 
     config PKG_ULAPACK_VER_NUM
         hex
-        default 0x10000 if PKG_USING_ULAPACK_V100
         default 0x99999 if PKG_USING_ULAPACK_LATEST_VERSION
 
 endif

--- a/misc/ulapack/Kconfig
+++ b/misc/ulapack/Kconfig
@@ -36,6 +36,17 @@ if PKG_USING_ULAPACK
         default n
 
     choice
+        prompt "Memory allocation"
+        default ULAPACK_USE_DYNAMIC_ALLOC
+        help
+            Select memory allocation method
+        config ULAPACK_USE_DYNAMIC_ALLOC
+            bool "Dynamic allocation"
+        config ULAPACK_USE_STATIC_ALLOC
+            bool "Static allocation"
+    endchoice
+
+    choice
         prompt "Version"
         default PKG_USING_ULAPACK_LATEST_VERSION
         help

--- a/misc/ulapack/Kconfig
+++ b/misc/ulapack/Kconfig
@@ -11,6 +11,12 @@ if PKG_USING_ULAPACK
         string
         default "/packages/misc/ulapack"
 
+    config ULAPACK_USING_LU
+        bool "LU decomposition example"
+        help
+            LU decomposition example
+        default n
+
     config ULAPACK_USING_SVD
         bool "SVD decomposition example"
         help

--- a/misc/ulapack/Kconfig
+++ b/misc/ulapack/Kconfig
@@ -17,6 +17,12 @@ if PKG_USING_ULAPACK
             Principal components analysis example
         default n
 
+    config ULAPACK_USING_POLYFIT
+        bool "polynomial regression example"
+        help
+            polynomial regression example
+        default n
+
     choice
         prompt "Version"
         default PKG_USING_ULAPACK_LATEST_VERSION

--- a/misc/ulapack/Kconfig
+++ b/misc/ulapack/Kconfig
@@ -11,6 +11,12 @@ if PKG_USING_ULAPACK
         string
         default "/packages/misc/ulapack"
 
+    config ULAPACK_USING_SVD
+        bool "SVD decomposition example"
+        help
+            SVD decomposition example
+        default n
+
     config ULAPACK_USING_PCA
         bool "Principal components analysis example"
         help

--- a/misc/ulapack/package.json
+++ b/misc/ulapack/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ulapack",
+  "description": "Linear algebra library for embedded devices",
+  "description_zh": "嵌入式线性代数库",
+  "keywords": [
+    "Linear Algebra",
+    "lapack"
+  ],
+  "category": "misc",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@hust.edu.cn"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/wuhanstudio/ulapack",
+  "homepage": "https://github.com/wuhanstudio/ulapack#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/ulapack.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
> LAPACK: linear algebra package 是非常经典的线性代数库。

### ulapack ( 9月30日 )

之前移植的 elapack 是从最早的 Fortran 转换成的 C 版本，并且提供了和 Matlab 兼容的接口，功能非常全，但是从 Fortran 转换过来很多数组是静态声明的，如果矩阵维度太大，一不小心就容易 stackoverflow，适合 Flash 非常大，内存也相对比较丰富的板子。

这个 ulapack 则是原生 C 实现的，矩阵的内存动态分配，更加轻量级，但是功能也就不是那么丰富，不过也包含了主流的矩阵运算，适合 Flash 比较小，内存也紧缺的板子。考虑到有些板子内存小到无法使用 heap，之后还是要在 KConfig 里增加静态、动态分配的选项。

包含例程：

- 矩阵 LU 分解
- 矩阵 SVD 分解
- 主成分分析 PCA
- 多项式拟合


> 两个软件包相互依赖，就放在一个 PR 里面了

----------------------

### ukal ( 10月01日 )

基于 ulapack 的卡尔曼滤波器。

包含例程:

- Extended kalman filter

-----------------------------------

### 内存分配 ( 10月03日 )

- 为 ulapack 增加了 内存动态/静态分配 选项
- 为 ukal 增加了 内存动态/静态分配 提示
- 增加静态分配内存时矩阵最大维度配置

### 内存占用对比

elapck (静态分配):

| Example | Memory |
|----------|-------------|
| linsolve 线性方程组 |  2 KB |
| qr 矩阵 QR 分解 |  2 KB |
| lu 矩阵 LU 分解 |  2 KB |
| svd 矩阵 SVD 分解 |  20 KB |
| eig 特征值和特征向量 | 30 KB |
| model 综合控制模型预测 | 20 KB |
| state 综合状态空间控制 | 800 KB |

ulapack (静态分配):

| Example | Memory |
|----------|-------------|
| lu 矩阵 LU 分解 |  15 KB |
| svd 矩阵 SVD 分解 |  20 KB |
| pca 主成分分析 | 35 KB |
| polyfit 多项式拟合 | 40 KB |
| ekal 卡尔曼滤波 | 120 KB |

不过 ulapack 既可以静态分配内存，也可以动态分配内存，如果动态分配那么所有的例程都可以在内存 30KB 以上的板子上运行。
