### PR TITLE
[peripherals][rosserial] Distinguish kinetic & melodic

### DIFF
--- a/peripherals/rosserial/Kconfig
+++ b/peripherals/rosserial/Kconfig
@@ -111,19 +111,31 @@ if PKG_USING_ROSSERIAL
 
     choice
         prompt "Version"
-        default PKG_USING_ROSSERIAL_LATEST_VERSION
+        default PKG_USING_ROSSERIAL_MLATEST_VERSION
         help
             Select the package version
-        config PKG_USING_ROSSERIAL_V100
-            bool "v1.0.0"
-        config PKG_USING_ROSSERIAL_LATEST_VERSION
-            bool "latest"
+        config PKG_USING_ROSSERIAL_KV100
+            bool "kinetic-v1.0.0"
+        config PKG_USING_ROSSERIAL_MV100
+            bool "melodic-v1.0.0"
+        config PKG_USING_ROSSERIAL_KLATEST_VERSION
+            bool "kinetic-latest"
+        config PKG_USING_ROSSERIAL_MLATEST_VERSION
+            bool "melodic-latest"
     endchoice
 
     config PKG_ROSSERIAL_VER
        string
-       default "v1.0.0"    if PKG_USING_ROSSERIAL_V100
-       default "latest"    if PKG_USING_ROSSERIAL_LATEST_VERSION
+       default "kinetic-v1.0.0"    if PKG_USING_ROSSERIAL_KV100
+       default "melodic-v1.0.0"    if PKG_USING_ROSSERIAL_MV100
+       default "kinetic-latest"    if PKG_USING_ROSSERIAL_KLATEST_VERSION
+       default "melodic-latest"    if PKG_USING_ROSSERIAL_MLATEST_VERSION
+
+    config PKG_ROSSERIAL_VER_NUM
+        hex
+        default 0x10000 if PKG_USING_ROSSERIAL_KV100
+        default 0x19999 if PKG_USING_ROSSERIAL_KLATEST_VERSION
+        default 0x20000 if PKG_USING_ROSSERIAL_MV100
+        default 0x29999 if PKG_USING_ROSSERIAL_MLATEST_VERSION
 
 endif
-

--- a/peripherals/rosserial/Kconfig
+++ b/peripherals/rosserial/Kconfig
@@ -47,53 +47,55 @@ if PKG_USING_ROSSERIAL
                     Hello World example using UART
                 default n
 
-            config ROSSERIAL_USING_BLINK_UART
-                bool "Blink       : blink example using UART"
-                help
-                    Blink : blink example using UART
-                default n
+            if PKG_ROSSERIAL_VER_NUM > 0x20000
+                config ROSSERIAL_USING_BLINK_UART
+                    bool "Blink       : blink example using UART"
+                    help
+                        Blink : blink example using UART
+                    default n
 
-            config ROSSERIAL_USING_BLINK_CLASS_UART
-                bool "Blink Class : blink class example using UART"
-                help
-                    Blink Class : blink class example using UART
-                default n
+                config ROSSERIAL_USING_BLINK_CLASS_UART
+                    bool "Blink Class : blink class example using UART"
+                    help
+                        Blink Class : blink class example using UART
+                    default n
 
-            config ROSSERIAL_USING_BUTTON_UART
-                bool "Button      : button example using UART"
-                help
-                    Button : button example using UART
-                default n
+                config ROSSERIAL_USING_BUTTON_UART
+                    bool "Button      : button example using UART"
+                    help
+                        Button : button example using UART
+                    default n
 
-            config ROSSERIAL_USING_PUB_SUB_UART
-                bool "PubSub      : publish and subscribe example using UART"
-                help
-                    PubSub : publish and subscribe example using UART
-                default n
+                config ROSSERIAL_USING_PUB_SUB_UART
+                    bool "PubSub      : publish and subscribe example using UART"
+                    help
+                        PubSub : publish and subscribe example using UART
+                    default n
 
-            config ROSSERIAL_USING_LOGGING_UART
-                bool "Logging     : logging example using UART"
-                help
-                    Logging : logging example using UART
-                default n
+                config ROSSERIAL_USING_LOGGING_UART
+                    bool "Logging     : logging example using UART"
+                    help
+                        Logging : logging example using UART
+                    default n
 
-            config ROSSERIAL_USING_TF_UART
-                bool "TF         : tf example using UART"
-                help
-                    TF : tf example using UART
-                default n
+                config ROSSERIAL_USING_TF_UART
+                    bool "TF         : tf example using UART"
+                    help
+                        TF : tf example using UART
+                    default n
 
-            config ROSSERIAL_USING_SERVICE_SERVER_UART
-                bool "Service server : service example using UART"
-                help
-                    Service server : service example using UART
-                default n
+                config ROSSERIAL_USING_SERVICE_SERVER_UART
+                    bool "Service server : service example using UART"
+                    help
+                        Service server : service example using UART
+                    default n
 
             config ROSSERIAL_USING_SERVICE_CLIENT_UART
                 bool "Service client : service example using UART"
                 help
                     Service client : service example using UART
                 default n
+            endif
         endif
 
         if ROSSERIAL_USE_TCP

--- a/peripherals/rosserial/package.json
+++ b/peripherals/rosserial/package.json
@@ -16,13 +16,25 @@
   "homepage": "https://github.com/wuhanstudio/rt-rosserial#readme",
   "site": [
     {
-      "version": "v1.0.0",
+      "version": "kinetic-v1.0.0",
       "URL": "https://github.com/wuhanstudio/rt-rosserial.git",
-      "filename": "rosserial-1.0.0.zip",
+      "filename": "rosserial-kinetic-1.0.0.zip",
+      "VER_SHA": "8368e65b025fae86669faecd4a324eb8a037457b"
+    },
+    {
+      "version": "melodic-v1.0.0",
+      "URL": "https://github.com/wuhanstudio/rt-rosserial.git",
+      "filename": "rosserial-melodic-1.0.0.zip",
       "VER_SHA": "762a758f61e773460f0657c44f7bc832106af0fc"
     },
     {
-      "version": "latest",
+      "version": "kinetic-latest",
+      "URL": "https://github.com/wuhanstudio/rt-rosserial.git",
+      "filename": "",
+      "VER_SHA": "kinetic"
+    },
+    {
+      "version": "melodic-latest",
       "URL": "https://github.com/wuhanstudio/rt-rosserial.git",
       "filename": "",
       "VER_SHA": "master"


### PR DESCRIPTION
ROS 的 Kinetic (Ubuntu 16) 和 Melodic (Ubuntu 18) 现在都用的比较多，因此开了 kinetic-latest 和 melodic-latest 分别维护，适配不同的 ROS 版本，之前还沒意识到 package.json 指定的 master 是分支名