### PR TITLE
[tools][coremark] new package coremark

### DIFF
--- a/tools/CoreMark/Kconfig
+++ b/tools/CoreMark/Kconfig
@@ -5,6 +5,13 @@ menuconfig PKG_USING_COREMARK
 
 if PKG_USING_COREMARK
 
+    config COREMARK_USE_FLOAT
+        select RT_USING_LIBC
+        bool "Show benchmark result in float number"
+        help
+            Show benchmark result in float number.
+        default n
+
     config COREMARK_ITERATIONS
         int "Run the benchmark for a specified number of iterations."
         default "3600"
@@ -28,4 +35,8 @@ if PKG_USING_COREMARK
         string
         default "latest" if PKG_USING_COREMARK_LATEST_VERSION
 
+    config CORE_MARK_HAS_FLOAT
+        int
+        default 1 if COREMARK_USE_FLOAT
+        default 0
 endif

--- a/tools/CoreMark/Kconfig
+++ b/tools/CoreMark/Kconfig
@@ -1,0 +1,31 @@
+
+menuconfig PKG_USING_COREMARK
+    bool "COREMARK: a benchmark that measures the performance of MCUs and CPUs."
+    default n
+
+if PKG_USING_COREMARK
+
+    config COREMARK_ITERATIONS
+        int "Run the benchmark for a specified number of iterations."
+        default "3600"
+    comment "You may ajust this number to make sure the benchmark runs for at least 10s"
+
+    config PKG_COREMARK_PATH
+        string
+        default "/packages/tools/CoreMark"
+
+    choice
+        prompt "Version"
+        default PKG_USING_COREMARK_LATEST_VERSION
+        help
+            Select the this package version
+            
+        config PKG_USING_COREMARK_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_COREMARK_VER
+        string
+        default "latest" if PKG_USING_COREMARK_LATEST_VERSION
+
+endif

--- a/tools/CoreMark/package.json
+++ b/tools/CoreMark/package.json
@@ -18,7 +18,7 @@
     {
       "version": "latest",
       "URL": "https://github.com/wuhanstudio/coremark.git",
-      "filename": "coremark.zip",
+      "filename": "",
       "VER_SHA": "master"
     }
   ]

--- a/tools/CoreMark/package.json
+++ b/tools/CoreMark/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "CoreMark",
+  "description": "EEMBC’s CoreMark® is a benchmark that measures the performance of microcontrollers (MCUs) and central processing units (CPUs) used in embedded systems.",
+  "description_zh": "EEMBC 的单片机性能测试小工具",
+  "keywords": [
+    "coremark",
+    "benchmark"
+  ],
+  "category": "tools",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@hust.edu.cn"
+  },
+  "license": "apache",
+  "repository": "https://github.com/wuhanstudio/coremark",
+  "homepage": "https://github.com/wuhanstudio/coremark#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/coremark.git",
+      "filename": "coremark.zip",
+      "VER_SHA": "master"
+    }
+  ]
+}

--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -8,5 +8,6 @@ source "$PKGS_DIR/packages/tools/rdb/Kconfig"
 source "$PKGS_DIR/packages/tools/qrcode/Kconfig"
 source "$PKGS_DIR/packages/tools/ulog_easyflash/Kconfig"
 source "$PKGS_DIR/packages/tools/adbd/Kconfig"
+source "$PKGS_DIR/packages/tools/coremark/Kconfig"
 
 endmenu

--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -8,6 +8,6 @@ source "$PKGS_DIR/packages/tools/rdb/Kconfig"
 source "$PKGS_DIR/packages/tools/qrcode/Kconfig"
 source "$PKGS_DIR/packages/tools/ulog_easyflash/Kconfig"
 source "$PKGS_DIR/packages/tools/adbd/Kconfig"
-source "$PKGS_DIR/packages/tools/coremark/Kconfig"
+source "$PKGS_DIR/packages/tools/CoreMark/Kconfig"
 
 endmenu


### PR DESCRIPTION
增加 CoreMark 软件包， MCU/CPU 性能测试小工具。

### STM32F103RC (72MHZ) ARMCC -O3 -Otime 跑分 135:

```
 \ | /
- RT -     Thread Operating System
 / | \     4.0.2 build Oct 13 2019
 2006 - 2019 Copyright by rt-thread team
msh >
msh >core_mark
Benchmark started, please make sure it runs for at least 10s.

2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 17776
Total time (secs): 17.776000
Iterations/Sec   : 135.013501
Iterations       : 2400
Compiler version : Please put compiler version here (e.g. gcc 4.1)
Compiler flags   :
Memory location  : STACK
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x382f
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 135.013501 / Please put compiler version here (e.g. gcc 4.1)  / STACK
```

### GD32VF103 (108MHz) GCC -Os 跑分 327:

```
 \ | /
- RT -     Thread Operating System
 / | \     4.0.2 build Oct 13 2019
 2006 - 2019 Copyright by rt-thread team
msh >
msh >core_mark
Benchmark started, please make sure it runs for at least 10s.

2K performance run parameters for coremark.
CoreMark Size    : 666
Total ticks      : 1178
Total time (secs): 11
Iterations/Sec   : 327
Iterations       : 3600
Compiler version : GCC8.2.0
Compiler flags   :
Memory location  : STACK
seedcrc          : 0xe9f5
[0]crclist       : 0xe714
[0]crcmatrix     : 0x1fd7
[0]crcstate      : 0x8e3a
[0]crcfinal      : 0x4bfc
Correct operation validated. See README.md for run and reporting rules.
CoreMark 1.0 : 327 / GCC8.2.0  / STACK
```
