### PR TITLE
[tools][dhrystone] New package dhrystone

### DIFF
--- a/tools/CoreMark/Kconfig
+++ b/tools/CoreMark/Kconfig
@@ -1,6 +1,6 @@
 
 menuconfig PKG_USING_COREMARK
-    bool "COREMARK: a benchmark that measures the performance of MCUs and CPUs."
+    bool "COREMARK : a benchmark that measures the performance of MCUs and CPUs."
     default n
 
 if PKG_USING_COREMARK

--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -9,5 +9,6 @@ source "$PKGS_DIR/packages/tools/qrcode/Kconfig"
 source "$PKGS_DIR/packages/tools/ulog_easyflash/Kconfig"
 source "$PKGS_DIR/packages/tools/adbd/Kconfig"
 source "$PKGS_DIR/packages/tools/CoreMark/Kconfig"
+source "$PKGS_DIR/packages/tools/dhrystone/Kconfig"
 
 endmenu

--- a/tools/dhrystone/Kconfig
+++ b/tools/dhrystone/Kconfig
@@ -1,0 +1,31 @@
+
+menuconfig PKG_USING_DHRYSTONE
+    bool "DHRYSTONE: a benchmark that measures the performance of MCUs and CPUs."
+    default n
+
+if PKG_USING_DHRYSTONE
+
+    config DHRY_ITERS
+        int "Run the benchmark for a specified number of iterations."
+        default "40000"
+    comment "You may ajust this number to make sure the benchmark runs long enough"
+
+    config PKG_DHRYSTONE_PATH
+        string
+        default "/packages/tools/dhrystone"
+
+    choice
+        prompt "Version"
+        default PKG_USING_DHRYSTONE_LATEST_VERSION
+        help
+            Select the this package version
+            
+        config PKG_USING_DHRYSTONE_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_DHRYSTONE_VER
+        string
+        default "latest" if PKG_USING_DHRYSTONE_LATEST_VERSION
+
+endif

--- a/tools/dhrystone/Kconfig
+++ b/tools/dhrystone/Kconfig
@@ -7,7 +7,7 @@ if PKG_USING_DHRYSTONE
 
     config DHRY_ITERS
         int "Run the benchmark for a specified number of iterations."
-        default "40000"
+        default "320000"
     comment "You may ajust this number to make sure the benchmark runs long enough"
 
     config PKG_DHRYSTONE_PATH

--- a/tools/dhrystone/package.json
+++ b/tools/dhrystone/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "Dhrystone",
+  "description": "Dhrystone is a benchmark that measures the performance of microcontrollers (MCUs) and central processing units (CPUs) used in embedded systems.",
+  "description_zh": "Dhrystone 单片机性能测试小工具",
+  "keywords": [
+    "dhrystone",
+    "benchmark"
+  ],
+  "category": "tools",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@hust.edu.cn"
+  },
+  "license": "apache",
+  "repository": "https://github.com/wuhanstudio/dhrystone",
+  "homepage": "https://github.com/wuhanstudio/dhrystone#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/dhrystone.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
历史悠久的 dhrystone 性能测试小工具：

## STM32F103 (ARMCC -O3 -Otime) 跑分: 79 DMIPS &  1.09 DMIPS/MHz

```
 \ | /
- RT -     Thread Operating System
 / | \     4.0.2 build Oct 15 2019
 2006 - 2019 Copyright by rt-thread team
msh >
msh >dhrystone_test

Dhrystone Benchmark, Version 2.1 (Language: C)

Program compiled without 'register' attribute

Execution starts, 320000 runs through Dhrystone
Execution ends

Final values of the variables used in the benchmark:

Int_Glob:            5
        should be:   5
Bool_Glob:           1
        should be:   1
Ch_1_Glob:           A
        should be:   A
Ch_2_Glob:           B
        should be:   B
Arr_1_Glob[8]:       7
        should be:   7
Arr_2_Glob[8][7]:    320010
        should be:   Number_Of_Runs + 10
Ptr_Glob->
  Ptr_Comp:          536892000
        should be:   (implementation-dependent)
  Discr:             0
        should be:   0
  Enum_Comp:         2
        should be:   2
  Int_Comp:          17
        should be:   17
  Str_Comp:          DHRYSTONE PROGRAM, SOME STRING
        should be:   DHRYSTONE PROGRAM, SOME STRING
Next_Ptr_Glob->
  Ptr_Comp:          536892000
        should be:   (implementation-dependent), same as above
  Discr:             0
        should be:   0
  Enum_Comp:         1
        should be:   1
  Int_Comp:          18
        should be:   18
  Str_Comp:          DHRYSTONE PROGRAM, SOME STRING
        should be:   DHRYSTONE PROGRAM, SOME STRING
Int_1_Loc:           5
        should be:   5
Int_2_Loc:           13
        should be:   13
Int_3_Loc:           7
        should be:   7
Enum_Loc:            1
        should be:   1
Str_1_Loc:           DHRYSTONE PROGRAM, 1'ST STRING
        should be:   DHRYSTONE PROGRAM, 1'ST STRING
Str_2_Loc:           DHRYSTONE PROGRAM, 2'ND STRING
        should be:   DHRYSTONE PROGRAM, 2'ND STRING

Microseconds for one run through Dhrystone: 7
Dhrystones per Second:                      139130
VAX  MIPS rating:                           79
```

## GD32VF103CB (GCC -Os): 50 DMIPS & 0.46 DMIPS/MHz

```
 \ | /
- RT -     Thread Operating System
 / | \     4.0.2 build Oct 14 2019
 2006 - 2019 Copyright by rt-thread team
msh >
msh >dhrystone_test

Dhrystone Benchmark, Version 2.1 (Language: C)

Program compiled without 'register' attribute

Execution starts, 320000 runs through Dhrystone
Execution ends

Final values of the variables used in the benchmark:

Int_Glob:            5
        should be:   5
Bool_Glob:           1
        should be:   1
Ch_1_Glob:           A
        should be:   A
Ch_2_Glob:           B
        should be:   B
Arr_1_Glob[8]:       7
        should be:   7
Arr_2_Glob[8][7]:    320010
        should be:   Number_Of_Runs + 10
Ptr_Glob->
  Ptr_Comp:          536884636
        should be:   (implementation-dependent)
  Discr:             0
        should be:   0
  Enum_Comp:         2
        should be:   2
  Int_Comp:          17
        should be:   17
  Str_Comp:          DHRYSTONE PROGRAM, SOME STRING
        should be:   DHRYSTONE PROGRAM, SOME STRING
Next_Ptr_Glob->
  Ptr_Comp:          536884636
        should be:   (implementation-dependent), same as above
  Discr:             0
        should be:   0
  Enum_Comp:         1
        should be:   1
  Int_Comp:          18
        should be:   18
  Str_Comp:          DHRYSTONE PROGRAM, SOME STRING
        should be:   DHRYSTONE PROGRAM, SOME STRING
Int_1_Loc:           5
        should be:   5
Int_2_Loc:           13
        should be:   13
Int_3_Loc:           7
        should be:   7
Enum_Loc:            1
        should be:   1
Str_1_Loc:           DHRYSTONE PROGRAM, 1'ST STRING
        should be:   DHRYSTONE PROGRAM, 1'ST STRING
Str_2_Loc:           DHRYSTONE PROGRAM, 2'ND STRING
        should be:   DHRYSTONE PROGRAM, 2'ND STRING

Microseconds for one run through Dhrystone: 11
Dhrystones per Second:                      89385
VAX  MIPS rating:                           50

```