### PR TITLE
add nr_micro_shell to Kconfig in tools.

### DIFF
--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -10,5 +10,6 @@ source "$PKGS_DIR/packages/tools/ulog_easyflash/Kconfig"
 source "$PKGS_DIR/packages/tools/adbd/Kconfig"
 source "$PKGS_DIR/packages/tools/CoreMark/Kconfig"
 source "$PKGS_DIR/packages/tools/dhrystone/Kconfig"
+source "$PKGS_DIR/packages/tools/nr_micro_shell/Kconfig"
 
 endmenu


### PR DESCRIPTION
将 ../nr_micro_shell/Kconfig 路径添加到 ../tools/Kconfig  文件中，使 ENV 工具能够识别下载nr_micro_shell package。