### PR TITLE
1.mymqtt的Kconfig文件误输入中文，造成menuconfig显示乱码的bug修复

### DIFF
--- a/iot/mymqtt/Kconfig
+++ b/iot/mymqtt/Kconfig
@@ -1,7 +1,7 @@
 
 # Kconfig file for package mymqtt
 menuconfig PKG_USING_MYMQTT
-    bool "MY MQTT：Eclipse Paho MQTT C/C++ client, A new efficient and stable way to realize for rt-thread."
+    bool "MY MQTT: Eclipse Paho MQTT C/C++ client, A new efficient and stable way to realize for rt-thread."
     default n
 
 if PKG_USING_MYMQTT


### PR DESCRIPTION
mymqtt的Kconfig误输入中文，造成menuconfig显示乱码的bug修复