### PR TITLE
TFM: Add Trusted firmware for M as package

### DIFF
--- a/security/Kconfig
+++ b/security/Kconfig
@@ -5,4 +5,5 @@ source "$PKGS_DIR/packages/security/libsodium/Kconfig"
 
 source "$PKGS_DIR/packages/security/tinycrypt/Kconfig"
 
+source "$PKGS_DIR/packages/security/trusted-firmware-m/Kconfig"
 endmenu

--- a/security/trusted-firmware-m/Kconfig
+++ b/security/trusted-firmware-m/Kconfig
@@ -1,0 +1,29 @@
+menuconfig PKG_USING_TFM
+    bool "TFM: Trusted firmware for M class"
+    default n
+
+if PKG_USING_TFM
+
+    config PKG_TFM_PATH
+        string
+        default "/packages/security/trusted-firmware-m"
+
+    choice
+        prompt "Version"
+        default PKG_USING_TFM_V1_BETA
+        help
+            Select the TFM version
+
+        config PKG_USING_TFM_V1_BETA
+            bool "v1.0-beta"
+
+        config PKG_USING_TFM_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_TFM_VER
+    string
+    default "v1.0-beta" if PKG_USING_TFM_V1_BETA
+    default "latest" if PKG_USING_TFM_LATEST_VERSION
+
+endif

--- a/security/trusted-firmware-m/package.json
+++ b/security/trusted-firmware-m/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "trusted-firmware-m",
+  "description": "Trusted firmware for M class",
+  "description_zh": "Cortex M系列架构安全固件",
+  "enable": "PKG_USING_TFM",
+  "keywords": [
+    "trusted-firmware-m"
+  ],
+  "category": "security",
+  "author": {
+    "name": "Trusted Firmware-M",
+    "email": "tf-m@lists.trustedfirmware.org",
+    "github": "RT-Thread-packages"
+  },
+  "license": " BSD-3-Clause",
+  "repository": "https://github.com/RT-Thread-packages/trusted-firmware-m",
+  "icon": "https://www.trustedfirmware.org/assets/TrustedFirmware-Logo_icon-23d65367b85d00eae99cdd3377394bf463027aabb9526ce499c547a32b14b933.png",
+  "homepage": "https://ci.trustedfirmware.org/job/tf-m-build-test-nightly/lastSuccessfulBuild/artifact/build-docs/tf-m_documents/install/doc/user_guide/html/index.html#",
+  "readme": "Trusted firmware for M class",
+  "site": [
+    {
+      "version": "v1.0-beta",
+      "URL": "https://github.com/RT-Thread-packages/trusted-firmware-m/archive/lpc-v1.0.zip",
+      "filename": "trusted-firmware-m-1.0-beta.zip"
+    },
+    {
+      "version": "latest",
+      "URL": "https://git.trustedfirmware.org/trusted-firmware-m.git/",
+      "filename": "trusted-firmware-m.zip",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
TFM is an implementation of SPE which compliant with PSA. Add TFM as a
package of RTT, it is the first step to get PSA certified for RTT.

Currently, TFM official repo does not support LPC55S69 board. We are waiting for the TFM contributor who is working on the LPC board enablement. This PR will make TFM package available in RTT menuconfig, and will update TFM package when LPC55S69 has merged into TFM repo.

Signed-off-by: Karl Zhang <karl.zhang@arm.com>