### PR TITLE
[peripherals][embARC_bsp] add synopsys embARC_bsp support

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -32,5 +32,6 @@ source "$PKGS_DIR/packages/peripherals/max17048/Kconfig"
 source "$PKGS_DIR/packages/peripherals/rplidar/Kconfig"
 source "$PKGS_DIR/packages/peripherals/as608/Kconfig"
 source "$PKGS_DIR/packages/peripherals/rc522/Kconfig"
+source "$PKGS_DIR/packages/peripherals/embARC_bsp/Kconfig"
 
 endmenu

--- a/peripherals/embARC_bsp/Kconfig
+++ b/peripherals/embARC_bsp/Kconfig
@@ -1,0 +1,31 @@
+
+# Kconfig file for package embARC_bsp
+menuconfig PKG_USING_EMBARC_BSP
+    bool "embARC_bsp(Synopsys ARC Processer Board Support Package Software) package"
+    default n
+
+if PKG_USING_EMBARC_BSP
+
+    config PKG_EMBARC_BSP_PATH
+        string
+        default "/packages/peripherals/embARC_bsp"
+
+    choice
+        prompt "Version"
+        default PKG_USING_EMBARC_BSP_UPSTREAM_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_EMBARC_BSP_UPSTREAM_VERSION
+            bool "upstream"
+        config PKG_USING_EMBARC_BSP_MASTER_VERSION
+            bool "master"
+    endchoice
+
+    config PKG_EMBARC_BSP_VER
+       string
+       default "upstream"    if PKG_USING_EMBARC_BSP_UPSTREAM_VERSION
+       default "master"    if PKG_USING_EMBARC_BSP_MASTER_VERSION
+
+endif
+

--- a/peripherals/embARC_bsp/package.json
+++ b/peripherals/embARC_bsp/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "embARC_bsp",
+  "description": "embARC_bsp(Synopsys ARC Processer Board Support Package Software ) package",
+  "description_zh": "Synopsys ARC 处理器 板级支持包",
+  "enable": "PKG_USING_EMBARC_BSP",
+  "keywords": [
+    "Synopsys ARC",
+    "embARC_bsp"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "Watson Zeng",
+    "email": "zhiwei@synopsys.com"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_bsp",
+  "site": [
+    {
+      "version": "upstream",
+      "URL": "https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_bsp.git",
+      "filename": "embarc_bsp-upstream.zip",
+      "VER_SHA": "upstream"
+    },
+    {
+      "version": "master",
+      "URL": "https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_bsp.git",
+      "filename": "embarc_bsp-master.zip",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
Add synopsys embARC_bsp support as a system package.

The embARC Board support Package (BSP) is a software distributions
aimed at facilitating the development and evaluation of embedded
systems based on Synopsys ARCv2 processors, which is designed to
provide a minimal board support package for ARC users by defining
consistent and simple software interfaces to the processors
and onboard devices.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>