### PR TITLE
TFM: clear the version name for LPC

### DIFF
--- a/security/trusted-firmware-m/Kconfig
+++ b/security/trusted-firmware-m/Kconfig
@@ -10,12 +10,12 @@ if PKG_USING_TFM
 
     choice
         prompt "Version"
-        default PKG_USING_TFM_V1_BETA
+        default PKG_USING_TFM_NXP_LPC55_V1_BETA
         help
             Select the TFM version
 
-        config PKG_USING_TFM_V1_BETA
-            bool "v1.0-beta"
+        config PKG_USING_TFM_NXP_LPC55_V1_BETA
+            bool "nxp-lpc55-v1.0-beta"
 
         config PKG_USING_TFM_LATEST_VERSION
             bool "latest"
@@ -23,7 +23,7 @@ if PKG_USING_TFM
 
     config PKG_TFM_VER
     string
-    default "v1.0-beta" if PKG_USING_TFM_V1_BETA
+    default "nxp-lpc55-v1.0-beta" if PKG_USING_TFM_NXP_LPC55_V1_BETA
     default "latest" if PKG_USING_TFM_LATEST_VERSION
 
 endif

--- a/security/trusted-firmware-m/package.json
+++ b/security/trusted-firmware-m/package.json
@@ -19,13 +19,13 @@
   "readme": "Trusted firmware for M class",
   "site": [
     {
-      "version": "v1.0-beta",
+      "version": "nxp-lpc55-v1.0-beta",
       "URL": "https://github.com/RT-Thread-packages/trusted-firmware-m/archive/v1.0-beta.zip",
-      "filename": "trusted-firmware-m-1.0-beta.zip"
+      "filename": "trusted-firmware-m-nxp-lpc55-v1.0-beta.zip"
     },
     {
       "version": "latest",
-      "URL": "https://git.trustedfirmware.org/trusted-firmware-m.git/",
+      "URL": "https://git.trustedfirmware.org/trusted-firmware-m.git",
       "filename": "trusted-firmware-m.zip",
       "VER_SHA": "master"
     }


### PR DESCRIPTION
LPC board now is not offically supported by TFM, we release a legacy LPC
support version with TFM 1.0 beta.

This change will add the version name into menuconfig for easier to
read.

Signed-off-by: Karl Zhang <karl.zhang@arm.com>