### PR TITLE
fixed typos: mater -> master

### DIFF
--- a/multimedia/mupdf/package.json
+++ b/multimedia/mupdf/package.json
@@ -26,7 +26,7 @@
       "version": "latest",
       "URL": "https://github.com/rtoslab/mupdf-rtt.git",
       "filename": "mupdf-rtt.zip",
-      "VER_SHA": "mater"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/peripherals/sensors/aht10/package.json
+++ b/peripherals/sensors/aht10/package.json
@@ -34,7 +34,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/aht10.git",
       "filename": "aht10.zip",
-      "VER_SHA": "mater"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/peripherals/sensors/ap3216c/package.json
+++ b/peripherals/sensors/ap3216c/package.json
@@ -34,7 +34,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/ap3216c.git",
       "filename": "ap3216c.zip",
-      "VER_SHA": "mater"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/peripherals/sensors/dht11/package.json
+++ b/peripherals/sensors/dht11/package.json
@@ -21,7 +21,7 @@
       "version": "latest",
       "URL": "https://github.com/murphyzhao/dht11_rtt.git",
       "filename": "dht11_rtt.zip",
-      "VER_SHA": "mater"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/peripherals/sht2x/package.json
+++ b/peripherals/sht2x/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/sht2x.git",
       "filename": "sht2x.zip",
-      "VER_SHA": "mater"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/system/minIni/package.json
+++ b/system/minIni/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/hichard/minIni.git",
       "filename": "minIni.zip",
-      "VER_SHA": "mater"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/system/rti/package.json
+++ b/system/rti/package.json
@@ -29,7 +29,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/rti.git",
       "filename": "Null for git package",
-      "VER_SHA": "mater"
+      "VER_SHA": "master"
     }
   ]
 }


### PR DESCRIPTION
在拉取一些软件包时，提示 error: pathspec 'mater' did not match any file(s) known to git. 经检查后将部分软件包的 latest 版本的 VER_SHA 值由 mater 修改为 master。