### PR TITLE
Add easyblink package

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -36,5 +36,6 @@ source "$PKGS_DIR/packages/peripherals/embARC_bsp/Kconfig"
 source "$PKGS_DIR/packages/peripherals/rtc/Kconfig"
 source "$PKGS_DIR/packages/peripherals/max7219/Kconfig"
 source "$PKGS_DIR/packages/peripherals/beep/Kconfig"
+source "$PKGS_DIR/packages/peripherals/easyblink/Kconfig"
 
 endmenu

--- a/peripherals/beep/Kconfig
+++ b/peripherals/beep/Kconfig
@@ -24,7 +24,7 @@ if PKG_USING_BEEP
     endchoice
 
     if PKG_BEEP_PASSIVE_BUZZER
-    
+
         config PKG_BEEP_PWM_DEV_NAME
             string "Setting current PWM device name."
             default "pwm1"
@@ -43,19 +43,24 @@ if PKG_USING_BEEP
             config PKG_BEEP_BLOCK_POWER_STOP
                 bool "Block the MCU power enter to stop mode on beeping."
                 default y
-                
+
             config PKG_BEEP_SUPPORT_PM_RUN_FREQ_CHANGE
                 bool "Beep with the original frequency at MCU run frequency changed."
                 default y
         endif
 
     endif
-    
+
+    if !PKG_USING_BEEP_V100
+        config PKG_BEEP_USING_MSH_CMD
+        bool "Beep the buzzer on console to test."
+        default n
+    endif
+
     if RT_USING_HEAP
         config PKG_BEEP_THREAD_STACK_USING_HEAP
         bool "Use heap with the beep thread stack created."
         default y
-    
     endif
 
     config PKG_BEEP_PATH

--- a/peripherals/beep/package.json
+++ b/peripherals/beep/package.json
@@ -1,7 +1,7 @@
 {
   "name": "beep",
-  "description": "Buzzer beep package on rt-thread's pin and pwm driver.",
-  "description_zh": "基于 rt-thread 的 pin 和 pwm 驱动的蜂鸣器鸣叫软件包。",
+  "description": "Control the buzzer to make beeps at different intervals.",
+  "description_zh": "基于 rt-thread 的 pin 和 pwm 驱动的蜂鸣器控制软件包，可以容易地驱动有源蜂鸣器或无源蜂鸣器，产生各种间隔长短的鸣叫声。",
   "enable": "PKG_USING_BEEP",
   "keywords": [
     "beep",
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "repository": "https://github.com/Sunwancn/rtt-pkgs-beep",
   "icon": "unknown",
-  "homepage": "unknown",
+  "homepage": "https://github.com/Sunwancn/rtt-pkgs-beep",
   "doc": "unknown",
   "site": [
     {

--- a/peripherals/easyblink/Kconfig
+++ b/peripherals/easyblink/Kconfig
@@ -1,0 +1,52 @@
+# Kconfig file for package easyblink
+
+menuconfig PKG_USING_EASYBLINK
+    bool "easyblink: Blink the LED easily and use a little RAM"
+    select RT_USING_SEMAPHORE
+    default n
+
+if PKG_USING_EASYBLINK
+
+    config PKG_EASYBLINK_MAX_LED_NUMS
+        int "Setting the max LED nums"
+        range 1 100
+        default 1
+
+    config PKG_EASYBLINK_USING_MSH_CMD
+        bool "Blink led on console to test"
+        default n
+
+    config PKG_EASYBLINK_USING_MUTEX
+        bool "Use mutex to make thread safe"
+        select RT_USING_MUTEX
+        default n
+
+    if RT_USING_HEAP
+        config PKG_EASYBLINK_USING_HEAP
+        bool "Use heap with the easyblink thread stack created"
+        default n
+    endif
+
+    config PKG_EASYBLINK_PATH
+        string
+        default "/packages/peripherals/easyblink"
+
+    choice
+        prompt "Version"
+        default PKG_USING_EASYBLINK_V100
+        help
+            Select the package version
+
+        config PKG_USING_EASYBLINK_V100
+            bool "v1.0.0"
+
+        config PKG_USING_EASYBLINK_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_EASYBLINK_VER
+        string
+        default "v1.0.0" if PKG_USING_EASYBLINK_V100
+        default "latest" if PKG_USING_EASYBLINK_LATEST_VERSION
+
+endif

--- a/peripherals/easyblink/package.json
+++ b/peripherals/easyblink/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "easyblink",
+  "description": "Blink the LED easily and use a little RAM for RT-Thread or RT-Thread Nano.",
+  "description_zh": "小巧轻便的 LED 控制软件包，可以容易地控制 LED 开、关、反转和各种间隔闪烁，占用 RAM 少，同时适用 RT-Thread 标准版和 Nano 版。",
+  "enable": "PKG_USING_EASYBLINK",
+  "keywords": [
+    "easyblink",
+    "blink",
+    "led"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "Sunwancn",
+    "email": "bwsheng2000@163.com",
+    "github": "Sunwancn"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/Sunwancn/rtt-pkgs-easyblink",
+  "icon": "unknown",
+  "homepage": "https://github.com/Sunwancn/rtt-pkgs-easyblink",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/Sunwancn/rtt-pkgs-easyblink/archive/v1.0.0.zip",
+      "filename": "rtt-pkgs-easyblink-1.0.0.zip",
+      "VER_SHA": "NULL"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/Sunwancn/rtt-pkgs-easyblink.git",
+      "filename": "Null for git package",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
1、添加了 easyblink 软件包。
小巧轻便的LED控制软件包，可以容易地控制LED开、关、反转和各种间隔闪烁，占用RAM少，可以设置成线程安全型的；不需要移植就可以同时适用 RT-Thread 标准版和 Nano 版。
2、更新了 beep 软件包的信息。