### PR TITLE
更新sqlite Kconfig文件，适配新PR的sqlite软件包

### DIFF
--- a/system/sqlite/Kconfig
+++ b/system/sqlite/Kconfig
@@ -15,10 +15,16 @@ if PKG_USING_SQLITE
         default "v3.19.3"
 
     config PKG_SQLITE_SQL_MAX_LEN
-        int  "sql statements max length"
+        int "SQL statements max length"
         default 1024
-
+    
+    config PKG_SQLITE_DB_NAME_MAX_LEN
+        int "Database filename(fullpath) length"
+        range 8 256
+        default 64
+ 
     config PKG_SQLITE_DAO_EXAMPLE
         bool "Enable example"
             default y
 endif
+

--- a/system/sqlite/Kconfig
+++ b/system/sqlite/Kconfig
@@ -14,10 +14,6 @@ if PKG_USING_SQLITE
         string
         default "v3.19.3"
 
-    config PKG_SQLITE_DB_NAME
-        string "database name(path)"
-        default "/rt.db"
-
     config PKG_SQLITE_SQL_MAX_LEN
         int  "sql statements max length"
         default 1024

--- a/system/sqlite/Kconfig
+++ b/system/sqlite/Kconfig
@@ -14,4 +14,15 @@ if PKG_USING_SQLITE
         string
         default "v3.19.3"
 
+    config PKG_SQLITE_DB_NAME
+        string "database name(path)"
+        default "/rt.db"
+
+    config PKG_SQLITE_SQL_MAX_LEN
+        int  "sql statements max length"
+        default 1024
+
+    config PKG_SQLITE_DAO_EXAMPLE
+        bool "Enable example"
+            default y
 endif


### PR DESCRIPTION
更新sqlite Kconfig文件，适配新PR的sqlite软件包，可实现数据库名称，SQL语句长度，是否开启DAO层示例功能，如下：
RT-Thread online packages  ---> 
    system packages  ---> 
        --- SQLite: a self-contained, high-reliability, embedded, full-featured, public-domain, SQL database engine.
        (/rt.db) Database name(path)
        (1024) SQL statements max length
        [*]   Enable example