### PR TITLE
package: Add new peripheral/bsp package nuclei-sdk

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -41,5 +41,6 @@ source "$PKGS_DIR/packages/peripherals/max7219/Kconfig"
 source "$PKGS_DIR/packages/peripherals/beep/Kconfig"
 source "$PKGS_DIR/packages/peripherals/easyblink/Kconfig"
 source "$PKGS_DIR/packages/peripherals/pms_series/Kconfig"
+source "$PKGS_DIR/packages/peripherals/nuclei_sdk/Kconfig"
 
 endmenu

--- a/peripherals/nuclei_sdk/Kconfig
+++ b/peripherals/nuclei_sdk/Kconfig
@@ -1,0 +1,34 @@
+
+# Only enable package nuclei_sdk when ARCH_NUCLEI is selected
+if ARCH_NUCLEI
+# Kconfig file for package nuclei_sdk
+menuconfig PKG_USING_NUCLEI_SDK
+    bool "Nuclei RISC-V Software Development Kit"
+    default n
+
+if PKG_USING_NUCLEI_SDK
+
+    config PKG_NUCLEI_SDK_PATH
+        string
+        default "/packages/peripherals/nuclei_sdk"
+
+    choice
+        prompt "Version"
+        default PKG_USING_NUCLEI_SDK_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_NUCLEI_SDK_V023
+            bool "0.2.3"
+
+        config PKG_USING_NUCLEI_SDK_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_NUCLEI_SDK_VER
+       string
+       default "0.2.3"     if PKG_USING_NUCLEI_SDK_V023
+       default "latest"    if PKG_USING_NUCLEI_SDK_LATEST_VERSION
+
+endif
+endif

--- a/peripherals/nuclei_sdk/package.json
+++ b/peripherals/nuclei_sdk/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "nuclei_sdk",
+  "description": "Nuclei RISC-V Software Development Kit",
+  "description_zh": "芯来科技RISC-V处理器软件开发包",  
+  "enable": "PKG_USING_NUCLEI_SDK", 
+  "keywords": [
+    "nuclei",
+    "risc-v",
+    "sdk",
+    "nmsis",
+    "nuclei-sdk"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "Huaqi Fang",
+    "email": "578567190@qq.com",
+    "github": "fanghuaqi"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/Nuclei-Software/nuclei-sdk",
+  "icon": "https://doc.nucleisys.com/nuclei_sdk/_static/nsdk_logo_small.png",
+  "homepage": "https://github.com/Nuclei-Software/nuclei-sdk",
+  "doc": "https://doc.nucleisys.com/nuclei_sdk",
+  "site": [
+    {
+      "version": "0.2.3",
+      "URL": "https://github.com/Nuclei-Software/nuclei-sdk.git",
+      "filename": "nuclei_sdk-0.2.3.zip",
+      "VER_SHA": "0.2.3"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/Nuclei-Software/nuclei-sdk.git",
+      "filename": "nuclei_sdk-latest.zip",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
Package `nuclei-sdk` is only used for supporting Nuclei RISC-V
processor based system, which included SoC peripherals
of different system.

For more information about it, click https://doc.nucleisys.com/nuclei_sdk

Signed-off-by: Huaqi Fang <578567190@qq.com>