### PR TITLE
[at_device] Add configs for bc28 class

### DIFF
--- a/iot/at_device/bc28/Kconfig
+++ b/iot/at_device/bc28/Kconfig
@@ -6,6 +6,38 @@ menuconfig AT_DEVICE_USING_BC28
 
 if AT_DEVICE_USING_BC28
 
+    choice
+        prompt "Select operating band"
+        default AT_DEVICE_BC28_OP_BAND_8
+
+        config AT_DEVICE_BC28_OP_BAND_1
+            bool "B1 @H-FDD: 2100MHz"
+
+        config AT_DEVICE_BC28_OP_BAND_3
+            bool "B3 @H-FDD: 1800MHz"
+
+        config AT_DEVICE_BC28_OP_BAND_5
+            bool "B5 @H-FDD: 850MHz"
+
+        config AT_DEVICE_BC28_OP_BAND_8
+            bool "B8 @H-FDD: 900MHz"
+
+        config AT_DEVICE_BC28_OP_BAND_20
+            bool "B20 @H-FDD: 800MHz"
+
+        config AT_DEVICE_BC28_OP_BAND_28
+            bool "B28 @H-FDD: 700MHz"
+    endchoice
+
+    config AT_DEVICE_BC28_OP_BAND
+       int
+       default 1     if AT_DEVICE_BC28_OP_BAND_1
+       default 3     if AT_DEVICE_BC28_OP_BAND_3
+       default 5     if AT_DEVICE_BC28_OP_BAND_5
+       default 8     if AT_DEVICE_BC28_OP_BAND_8
+       default 20    if AT_DEVICE_BC28_OP_BAND_20
+       default 28    if AT_DEVICE_BC28_OP_BAND_28
+
     config AT_DEVICE_BC28_INIT_ASYN
         bool "Enable initialize by thread"
         default n

--- a/iot/at_device/bc28/Kconfig
+++ b/iot/at_device/bc28/Kconfig
@@ -32,6 +32,30 @@ if AT_DEVICE_USING_BC28
             int "The maximum length of receive line buffer"
             default 512
 
+        config BC28_SAMPLE_MIN_SOCKET
+            int "The minimum available socket id"
+            default 0
+
+        choice
+            prompt "Select baud rate"
+            default BC28_SAMPLE_BAUD_RATE_9600
+
+            config BC28_SAMPLE_BAUD_RATE_4800
+                bool "4800"
+
+            config BC28_SAMPLE_BAUD_RATE_9600
+                bool "9600"
+
+            config BC28_SAMPLE_BAUD_RATE_115200
+                bool "115200"
+        endchoice
+
+        config BC28_SAMPLE_BAUD_RATE
+            int
+            default 4800      if BC28_SAMPLE_BAUD_RATE_4800
+            default 9600      if BC28_SAMPLE_BAUD_RATE_9600
+            default 115200    if BC28_SAMPLE_BAUD_RATE_115200
+
     endif
 
 endif

--- a/iot/bc28_mqtt/Kconfig
+++ b/iot/bc28_mqtt/Kconfig
@@ -34,6 +34,38 @@ if PKG_USING_BC28_MQTT
        default 9600      if PKG_USING_BC28_MQTT_BAUD_RATE_9600
        default 115200    if PKG_USING_BC28_MQTT_BAUD_RATE_115200
 
+    choice
+        prompt "Select operating band"
+        default PKG_USING_BC28_MQTT_OP_BAND_8
+
+        config PKG_USING_BC28_MQTT_OP_BAND_1
+            bool "B1 @H-FDD: 2100MHz"
+
+        config PKG_USING_BC28_MQTT_OP_BAND_3
+            bool "B3 @H-FDD: 1800MHz"
+
+        config PKG_USING_BC28_MQTT_OP_BAND_5
+            bool "B5 @H-FDD: 850MHz"
+
+        config PKG_USING_BC28_MQTT_OP_BAND_8
+            bool "B8 @H-FDD: 900MHz"
+
+        config PKG_USING_BC28_MQTT_OP_BAND_20
+            bool "B20 @H-FDD: 800MHz"
+
+        config PKG_USING_BC28_MQTT_OP_BAND_28
+            bool "B28 @H-FDD: 700MHz"
+    endchoice
+
+    config PKG_USING_BC28_MQTT_OP_BAND
+       int
+       default 1     if PKG_USING_BC28_MQTT_OP_BAND_1
+       default 3     if PKG_USING_BC28_MQTT_OP_BAND_3
+       default 5     if PKG_USING_BC28_MQTT_OP_BAND_5
+       default 8     if PKG_USING_BC28_MQTT_OP_BAND_8
+       default 20    if PKG_USING_BC28_MQTT_OP_BAND_20
+       default 28    if PKG_USING_BC28_MQTT_OP_BAND_28
+
     config PKG_USING_BC28_RESET_PIN
         int "Reset pin"
         default 5


### PR DESCRIPTION
为增加 bc28 at_device 软件包的灵活性，增加了 BC28_SAMPLE_MIN_SOCKET 和 BC28_SAMPLE_BAUD_RATE 两个配置项，分别用于配置模块可用的最小 socket 号和 UART 波特率。