### PR TITLE
kawaii mqtt release v1.1.0 ...

### DIFF
--- a/iot/kawaii-mqtt/Kconfig
+++ b/iot/kawaii-mqtt/Kconfig
@@ -20,8 +20,8 @@ if PKG_USING_KAWAII_MQTT
             default 5000
     endif
 
-    config KAWAII_MQTT_USE_SAL
-        bool "use SAL"
+    config KAWAII_MQTT_NETSOCKET_USE_SAL
+        bool "using SAL"
         default n
 
     config KAWAII_MQTT_LOG_IS_SALOF
@@ -29,64 +29,64 @@ if PKG_USING_KAWAII_MQTT
         default y
     
     if KAWAII_MQTT_LOG_IS_SALOF
-        config KAWAII_MQTT_USE_LOG
-            bool "use log"
+        config SALOF_USING_LOG
+            bool "salof using log"
             default y
         
-        if KAWAII_MQTT_USE_LOG
-            config KAWAII_MQTT_USE_SALOF
-                bool "use salof"
+        if SALOF_USING_LOG
+            config SALOF_USING_SALOF
+                bool "using salof"
                 default y
-            
-            if !KAWAII_MQTT_USE_IDLE_HOOK
-                if KAWAII_MQTT_USE_SALOF
-                    config KAWAII_MQTT_SALOF_BUFF_SIZE
+
+            if !SALOF_USING_IDLE_HOOK
+                if SALOF_USING_SALOF
+                    config SALOF_BUFF_SIZE
                         int "salof buff size"
                         default 512
 
-                    config KAWAII_MQTT_SALOF_FIFO_SIZE
+                    config SALOF_FIFO_SIZE
                         int "salof fifo size"
                         default 2048
                     
-                    config KAWAII_MQTT_SALOF_THREAD_STACK_SIZE
-                        int "salof thread size"
+                    config SALOF_TASK_STACK_SIZE
+                        int "salof task size"
                         default 2048
 
-                    config KAWAII_MQTT_SALOF_THREAD_TICK
-                        int "salof thread tick"
+                    config SALOF_TASK_TICK
+                        int "salof task tick"
                         default 50
                 endif 
             endif
 
-            config KAWAII_MQTT_LOG_COLOR
-                bool "use color"
+            config SALOF_LOG_COLOR
+                bool "using color"
                 default n
 
-            config KAWAII_MQTT_LOG_TS
-                bool "use timestamp"
+            config SALOF_LOG_TS
+                bool "using timestamp"
                 default n
 
-            config KAWAII_MQTT_LOG_TAR
-                bool "use tar"
+            config SALOF_LOG_TAR
+                bool "using tar"
                 default n
-            
-            if KAWAII_MQTT_USE_SALOF
-                config KAWAII_MQTT_USE_IDLE_HOOK
-                    bool "use idle thread hook"
+                config SALOF_USING_IDLE_HOOK
+                    bool "using idle thread hook"
                     default n
-            endif
+            
+            config SALOF_LOG_LEVEL
+                    int "salof output log level "
+                    default KAWAII_MQTT_LOG_LEVEL    
         endif
     endif
 
     config KAWAII_MQTT_LOG_LEVEL
         int "select output log level"
-        default 5
+        default 4
         help
-            1 : KAWAII_MQTT_ASSERT_LEVEL
-            2 : KAWAII_MQTT_ERR_LEVEL
-            3 : KAWAII_MQTT_WARN_LEVEL
-            4 : KAWAII_MQTT_INFO_LEVEL
-            5 : KAWAII_MQTT_DEBUG_LEVEL
+            1 : KAWAII_MQTT_LOG_ERR_LEVEL
+            2 : KAWAII_MQTT_LOG_WARN_LEVEL
+            3 : KAWAII_MQTT_LOG_INFO_LEVEL
+            4 : KAWAII_MQTT_LOG_DEBUG_LEVEL
 
     config KAWAII_MQTT_VERSION
         int "mqtt version, 4 is mqtt 3.1.1, 3 is mqtt 3.1"
@@ -156,6 +156,9 @@ if PKG_USING_KAWAII_MQTT
 
         config PKG_USING_KAWAII_MQTT_V102
             bool "v1.0.2"
+                
+        config PKG_USING_KAWAII_MQTT_V110
+            bool "v1.1.0"
 
         config PKG_USING_KAWAII_MQTT_LATEST_VERSION
             bool "latest"
@@ -165,6 +168,7 @@ if PKG_USING_KAWAII_MQTT
        string
        default "v1.0.0"    if PKG_USING_KAWAII_MQTT_V100
        default "v1.0.2"    if PKG_USING_KAWAII_MQTT_V102
+       default "v1.1.0"    if PKG_USING_KAWAII_MQTT_V110
        default "latest"    if PKG_USING_KAWAII_MQTT_LATEST_VERSION
 
 endif

--- a/iot/kawaii-mqtt/package.json
+++ b/iot/kawaii-mqtt/package.json
@@ -30,6 +30,11 @@
       "filename": "kawaii-mqtt-v1.0.2.zip"
     },
     {
+      "version": "v1.1.0",
+      "URL": "https://github.com/jiejieTop/kawaii-mqtt/archive/v1.1.0.zip",
+      "filename": "kawaii-mqtt-v1.1.0.zip"
+    },
+    {
       "version": "latest",
       "URL": "https://github.com/jiejieTop/kawaii-mqtt.git",
       "filename": "kawaii-mqtt.zip",


### PR DESCRIPTION
A larger version of the update, refactoring part of the code, optimizing the logic of MQTT processing, improving the overall stability, supporting multiple clients, supporting setting the will, optimizing the API interface, and adding multiple cloud platforms Test code and documentation, add online code generation tool, online cutting configuration tool,

emmm.... the readme of the project homepage has been updated. I hope that the description of the software package on the rt-thread official website can be updated synchronously  (including  License)