### PR TITLE
Add ramdisk block device

### DIFF
--- a/system/Kconfig
+++ b/system/Kconfig
@@ -20,5 +20,6 @@ source "$PKGS_DIR/packages/system/EV/Kconfig"
 source "$PKGS_DIR/packages/system/syswatch/Kconfig"
 source "$PKGS_DIR/packages/system/sys_load_monitor/Kconfig"
 source "$PKGS_DIR/packages/system/plccore/Kconfig"
+source "$PKGS_DIR/packages/system/ramdisk/Kconfig"
 
 endmenu

--- a/system/ramdisk/Kconfig
+++ b/system/ramdisk/Kconfig
@@ -1,0 +1,32 @@
+
+# Kconfig file for package ramdisk
+menuconfig PKG_USING_RAMDISK
+    bool "ramdisk: A RAM memory block device."
+    default n
+
+if PKG_USING_RAMDISK
+
+    config PKG_RAMDISK_PATH
+        string
+        default "/packages/system/ramdisk"
+
+    choice
+        prompt "Version"
+        default PKG_USING_RAMDISK_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_RAMDISK_V010
+            bool "v0.1.0"
+
+        config PKG_USING_RAMDISK_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_RAMDISK_VER
+       string
+       default "v0.1.0"    if PKG_USING_RAMDISK_V010
+       default "latest"    if PKG_USING_RAMDISK_LATEST_VERSION
+
+endif
+

--- a/system/ramdisk/package.json
+++ b/system/ramdisk/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "ramdisk",
+  "description": "A RAM memory block device.",
+  "description_zh": "内存块设备",
+  "enable": "PKG_USING_RAMDISK",
+  "keywords": [
+    "ramdisk"
+  ],
+  "category": "system",
+  "author": {
+    "name": "majianjia",
+    "email": "majianjia@live.com",
+    "github": "majianjia"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/majianjia/ramdisk",
+  "icon": "unknown",
+  "homepage": "https://github.com/majianjia/ramdisk#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v0.1.0",
+      "URL": "https://github.com/majianjia/ramdisk/archive/v0.1.0.zip",
+      "filename": "ramdisk-0.1.0.zip",
+      "VER_SHA": "NULL"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/majianjia/ramdisk.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
A ramdisk block device can be formatted.
- Replace ROMFS as root dir
- Fast file caching.
- Works like any other block device.

Originally I wanted to dynamically create dir in root dir. But it is not possible when using ROMFS as root. The original RTT RAMFS does not support dir. Thus I wrote this simplified ramdisk based on the block device framework. It works just like a normal block device. 

Very handy when working with SDRAM and formatted to a filesystem. 
