### PR TITLE
[Sensor] Fill in missing package information (rt3020)

### DIFF
--- a/peripherals/sensors/Kconfig
+++ b/peripherals/sensors/Kconfig
@@ -39,5 +39,6 @@ menuconfig PKG_USING_SENSORS_DRIVERS
         source "$PKGS_DIR/packages/peripherals/sensors/sr04/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/ccs811/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/pmsxx/Kconfig"
+        source "$PKGS_DIR/packages/peripherals/sensors/rt3020/Kconfig"
         
     endif


### PR DESCRIPTION
在查阅sensor软件包代码时发现，目前一共有35个sensor软包，但是Kconfig中只记录了34个。仔细对照，发现漏了RT3020软件包呀。。。难怪 rt3020 软件包的下载量是零 :cry: 
