### PR TITLE
Add the peripheral driver for wk2124

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -50,5 +50,6 @@ source "$PKGS_DIR/packages/peripherals/quick_led/Kconfig"
 source "$PKGS_DIR/packages/peripherals/PAJ7620/Kconfig"
 source "$PKGS_DIR/packages/peripherals/agile_console/Kconfig"
 source "$PKGS_DIR/packages/peripherals/ld3320/Kconfig"
+source "$PKGS_DIR/packages/peripherals/wk2124/Kconfig"
 
 endmenu

--- a/peripherals/wk2124/Kconfig
+++ b/peripherals/wk2124/Kconfig
@@ -1,0 +1,92 @@
+
+# Kconfig file for package wk2124
+menuconfig PKG_USING_WK2124
+    bool "wk2124: spi wk2124 driver library."
+    default n
+    select RT_USING_PIN
+    select RT_USING_SPI
+
+if PKG_USING_WK2124
+
+    config PKG_WK2124_PATH
+        string
+        default "/packages/peripherals/wk2124"
+
+    config PKG_USING_UART_SWK1
+        bool "Enable UART SWK1"
+        default y
+
+    config PKG_USING_UART_SWK2
+        bool "Enable UART SWK2"
+        default y
+
+    config PKG_USING_UART_SWK3
+        bool "Enable UART SWK3"
+        default y
+
+    config PKG_USING_UART_SWK4
+        bool "Enable UART SWK4"
+        default y
+
+    config WK2124_DEVICE_EXTERN_CONFIG
+         bool
+         default n
+
+    if !WK2124_DEVICE_EXTERN_CONFIG
+        menu "WK2124 device configure"
+
+            config WK2124_SPI_DEVICE
+                string "SPI device name"
+                default "spi2dev"
+
+            config WK2124_IRQ_PIN
+                int "IRQ pin number"
+                default 17
+
+            choice
+                prompt "Select crystal frequency"
+                default WK2124_Fosc_11059200
+
+                config WK2124_Fosc_1843200
+                    bool "1.8432MHz"
+                config WK2124_Fosc_3686400
+                    bool "3.6864MHz"
+                config WK2124_Fosc_7372800
+                    bool "7.3728MHz"
+                config WK2124_Fosc_11059200
+                    bool "11.0592MHz"
+                config WK2124_Fosc_14745600
+                    bool "14.7456MHz"
+                config WK2124_Fosc_8000000
+                    bool "8MHz"
+                config WK2124_Fosc_16000000
+                    bool "16MHz"
+                config WK2124_Fosc_24000000
+                    bool "24MHz"
+                config WK2124_Fosc_32000000
+                    bool "32MHz"
+            endchoice
+
+        endmenu
+    endif
+
+    choice
+        prompt "Version"
+        default PKG_USING_WK2124_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_WK2124_V100
+            bool "v1.0.0"
+
+        config PKG_USING_WK2124_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_WK2124_VER
+       string
+       default "v1.0.0"    if PKG_USING_WK2124_V100
+       default "latest"    if PKG_USING_WK2124_LATEST_VERSION
+
+endif
+

--- a/peripherals/wk2124/package.json
+++ b/peripherals/wk2124/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "wk2124",
+  "description": "wk2124(spi to uart) driver library.",
+  "description_zh": "wk2124 spi转四串口芯片的驱动库。",  
+  "enable": "PKG_USING_WK2124",
+  "keywords": [
+    "wk2124"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "YaohongLi",
+    "email": "1035285359@qq.com",
+    "github": "MrMichael"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/MrMichael/wk2124",
+  "icon": "unknown",
+  "homepage": "https://github.com/MrMichael/wk2124#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/MrMichael/wk2124/archive/1.0.0.zip",
+      "filename": "wk2124-1.0.0.zip",
+      "VER_SHA": "NULL"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/MrMichael/wk2124.git",
+      "filename": "Null for git package",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
Add a new peripheral driver of wk2124, which is a SPI to serial chip. It helps the chip expand more uart serial ports