### PR TITLE
增加了Tensorflow Lite Micro软件包索引

### DIFF
--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -29,5 +29,6 @@ source "$PKGS_DIR/packages/misc/crclib/Kconfig"
 source "$PKGS_DIR/packages/misc/threes/Kconfig"
 source "$PKGS_DIR/packages/misc/2048/Kconfig"
 source "$PKGS_DIR/packages/misc/lwgps/Kconfig"
+source "$PKGS_DIR/packages/misc/TensorflowLiteMicro/Kconfig"
 
 endmenu

--- a/misc/TensorflowLiteMicro/Kconfig
+++ b/misc/TensorflowLiteMicro/Kconfig
@@ -1,0 +1,45 @@
+
+# Kconfig file for package TensorflowLiteMicro
+menuconfig PKG_USING_TENSORFLOWLITEMICRO
+    bool "Tensorflow Lite Micro: a lightweight deep learning end-test inference framework for RT-Thread operating system ."
+    select RT_USING_CPLUSPLUS
+    default n
+
+if PKG_USING_TENSORFLOWLITEMICRO
+
+    config PKG_TENSORFLOWLITEMICRO_PATH
+        string
+        default "/packages/misc/TensorflowLiteMicro"
+
+    choice
+        prompt "Version"
+        default PKG_USING_TENSORFLOWLITEMICRO_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_TENSORFLOWLITEMICRO_V100
+            bool "v1.0.0"
+
+        config PKG_USING_TENSORFLOWLITEMICRO_LATEST_VERSION
+            bool "latest"
+    endchoice
+    
+    choice
+        prompt "Select Offical Example"
+
+        config PKG_USING_TENSORFLOWLITEMICRO_AUDIO_EXAMPLE
+            bool "Enable Tensorflow Lite Micro audio example"
+            default n
+
+        config PKG_USING_TENSORFLOWLITEMICRO_NO_EXAMPLE
+            bool "No Tensorflow Lite Micro Example"
+            default y
+    endchoice
+
+    config PKG_TENSORFLOWLITEMICRO_VER
+       string
+       default "v1.0.0"    if PKG_USING_TENSORFLOWLITEMICRO_V100
+       default "latest"    if PKG_USING_TENSORFLOWLITEMICRO_LATEST_VERSION
+
+endif
+

--- a/misc/TensorflowLiteMicro/package.json
+++ b/misc/TensorflowLiteMicro/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "TensorflowLiteMicro",
+  "description": "Tensorflow Lite Micro package, a lightweight deep learning end-test inference framework for RT-Thread operating system .",
+  "description_zh": "用于rt-thread操作系统的轻量级深度学习端侧推理框架Tensorflow Lite软件包。",  
+  "enable": "PKG_USING_TENSORFLOWLITEMICRO", 
+  "keywords": [
+    "TensorflowLiteMicro"
+  ],
+  "category": "misc",
+  "author": {
+    "name": "QingChuanWS",
+    "email": "bingshan45@163.com",
+    "github": "QingChuanWS"
+  },
+  "license": "LGPLv2.1",
+  "repository": "https://github.com/QingChuanWS/TensorflowLiteMicro",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/QingChuanWS/TensorflowLiteMicro.git",
+      "filename": "TensorflowLiteMicro-1.0.0.zip",
+      "VER_SHA": "de6444f5af275b512fd98f8d87b1653898e0fa0d"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/QingChuanWS/TensorflowLiteMicro.git",
+      "filename": "TensorflowLiteMicro.zip",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
这是2020暑期开源软件供应链Tensorflow LIte Micro移植到基于rtt内核的树莓派4项目的延伸, 在成功将Tensorflow LIte Micro移植到树莓派4之后, 考虑TFLiteMicro本身具有平台隔离的特性, 所以我尝试将其制作为软件包, 就有了这份PR.

由于时间仓促, 软件包的功能, 文档等诸多方面还都有待完善,  我回持续更新软件包的信息, 使其适用于更多基于RTT内核的硬件, 也请您在百忙之中可以揽阅软件包的情况, 您提出的意见和建议我都会仔细考虑的.