### PR TITLE
[peripherals][u8g2] select cpp dependency

### DIFF
--- a/peripherals/u8g2/Kconfig
+++ b/peripherals/u8g2/Kconfig
@@ -3,6 +3,8 @@
 menuconfig PKG_USING_U8G2
     bool "U8G2: a monochrome graphic library"
     select RT_USING_PIN
+    select RT_USING_CPLUSPLUS  if PKG_U8G2_VER_NUM > 0x20000
+    select RT_USING_POSIX      if PKG_U8G2_VER_NUM > 0x20000
     default n
 
 if PKG_USING_U8G2


### PR DESCRIPTION
如果选择了软件包的 C++ 版本，默认选中 C++ 依赖