### PR TITLE
更新了tag版本(之前的v1.0.0版本有bug)

### DIFF
--- a/misc/TensorflowLiteMicro/package.json
+++ b/misc/TensorflowLiteMicro/package.json
@@ -19,7 +19,7 @@
       "version": "v1.0.0",
       "URL": "https://github.com/QingChuanWS/TensorflowLiteMicro.git",
       "filename": "TensorflowLiteMicro-1.0.0.zip",
-      "VER_SHA": "de6444f5af275b512fd98f8d87b1653898e0fa0d"
+      "VER_SHA": "555c14d902c1d7ebd5b6a725e931d882f42d80d6"
     },
     {
       "version": "latest",


### PR DESCRIPTION
对Tensorflow Lite Micro软件包进行了一次深度矫正, 之前的v1.0.0版本实际是不能正确使用的, 经过此次修正之后的软件包才是真正意义上的v1.0.0, 故提交一个pr