### PR TITLE
Tensorflow Lite Micro软件包更新

### DIFF
--- a/misc/TensorflowLiteMicro/Kconfig
+++ b/misc/TensorflowLiteMicro/Kconfig
@@ -44,11 +44,11 @@ if PKG_USING_TENSORFLOWLITEMICRO
 
         config PKG_USING_TENSORFLOWLITEMICRO_REFERENCE
             bool "Using Tensorflow Lite reference operations"
-            default n
+            default y
 
         config PKG_USING_TENSORFLOWLITEMICRO_CMSISNN
             bool "Using Tensorflow Lite CMSIS NN operations"
-            default y
+            default n
     endchoice
 
     config PKG_TENSORFLOWLITEMICRO_VER

--- a/misc/TensorflowLiteMicro/Kconfig
+++ b/misc/TensorflowLiteMicro/Kconfig
@@ -9,13 +9,16 @@ if PKG_USING_TENSORFLOWLITEMICRO
 
     config PKG_TENSORFLOWLITEMICRO_PATH
         string
-        default "/packages/misc/TensorflowLiteMicro"
+        default "/packages/TensorflowLiteMicro"
 
     choice
         prompt "Version"
         default PKG_USING_TENSORFLOWLITEMICRO_LATEST_VERSION
         help
             Select the package version
+
+        config PKG_USING_TENSORFLOWLITEMICRO_V101
+            bool "v1.0.1"
 
         config PKG_USING_TENSORFLOWLITEMICRO_V100
             bool "v1.0.0"
@@ -50,6 +53,7 @@ if PKG_USING_TENSORFLOWLITEMICRO
 
     config PKG_TENSORFLOWLITEMICRO_VER
        string
+       default "v1.0.1"    if PKG_USING_TENSORFLOWLITEMICRO_V101
        default "v1.0.0"    if PKG_USING_TENSORFLOWLITEMICRO_V100
        default "latest"    if PKG_USING_TENSORFLOWLITEMICRO_LATEST_VERSION
 

--- a/misc/TensorflowLiteMicro/Kconfig
+++ b/misc/TensorflowLiteMicro/Kconfig
@@ -36,6 +36,18 @@ if PKG_USING_TENSORFLOWLITEMICRO
             default y
     endchoice
 
+    choice
+    prompt "Select Tensorflow Lite Operations Type"
+
+    config PKG_USING_TENSORFLOWLITEMICRO_REFERENCE
+        bool "Using Tensorflow Lite reference operations"
+        default n
+
+    config PKG_USING_TENSORFLOWLITEMICRO_CMSISNN
+        bool "Using Tensorflow Lite CMSIS NN operations"
+        default y
+    endchoice
+
     config PKG_TENSORFLOWLITEMICRO_VER
        string
        default "v1.0.0"    if PKG_USING_TENSORFLOWLITEMICRO_V100

--- a/misc/TensorflowLiteMicro/Kconfig
+++ b/misc/TensorflowLiteMicro/Kconfig
@@ -9,7 +9,7 @@ if PKG_USING_TENSORFLOWLITEMICRO
 
     config PKG_TENSORFLOWLITEMICRO_PATH
         string
-        default "/packages/TensorflowLiteMicro"
+        default "/packages/misc/TensorflowLiteMicro"
 
     choice
         prompt "Version"

--- a/misc/TensorflowLiteMicro/Kconfig
+++ b/misc/TensorflowLiteMicro/Kconfig
@@ -1,7 +1,7 @@
 
 # Kconfig file for package TensorflowLiteMicro
 menuconfig PKG_USING_TENSORFLOWLITEMICRO
-    bool "Tensorflow Lite Micro: a lightweight deep learning end-test inference framework for RT-Thread operating system ."
+    bool "Tensorflow Lite Micro: a lightweight deep learning end-test inference framework for RT-Thread operating system."
     select RT_USING_CPLUSPLUS
     default n
 
@@ -37,15 +37,15 @@ if PKG_USING_TENSORFLOWLITEMICRO
     endchoice
 
     choice
-    prompt "Select Tensorflow Lite Operations Type"
+        prompt "Select Tensorflow Lite Operations Type"
 
-    config PKG_USING_TENSORFLOWLITEMICRO_REFERENCE
-        bool "Using Tensorflow Lite reference operations"
-        default n
+        config PKG_USING_TENSORFLOWLITEMICRO_REFERENCE
+            bool "Using Tensorflow Lite reference operations"
+            default n
 
-    config PKG_USING_TENSORFLOWLITEMICRO_CMSISNN
-        bool "Using Tensorflow Lite CMSIS NN operations"
-        default y
+        config PKG_USING_TENSORFLOWLITEMICRO_CMSISNN
+            bool "Using Tensorflow Lite CMSIS NN operations"
+            default y
     endchoice
 
     config PKG_TENSORFLOWLITEMICRO_VER

--- a/misc/TensorflowLiteMicro/package.json
+++ b/misc/TensorflowLiteMicro/package.json
@@ -1,11 +1,9 @@
 {
   "name": "TensorflowLiteMicro",
-  "description": "Tensorflow Lite Micro package, a lightweight deep learning end-test inference framework for RT-Thread operating system .",
+  "description": "a lightweight deep learning inference framework based on Google Tensorflow Lite for RT-Thread operating system.",
   "description_zh": "用于rt-thread操作系统的轻量级深度学习端侧推理框架Tensorflow Lite软件包。",  
   "enable": "PKG_USING_TENSORFLOWLITEMICRO", 
-  "keywords": [
-    "TensorflowLiteMicro"
-  ],
+  "keywords": ["TensorflowLiteMicro","ML", "AI", "neural-network", "C++", "lightweight"],
   "category": "misc",
   "author": {
     "name": "QingChuanWS",
@@ -14,17 +12,27 @@
   },
   "license": "LGPLv2.1",
   "repository": "https://github.com/QingChuanWS/TensorflowLiteMicro",
+  "icon": "unknown",
+  "homepage": "https://github.com/QingChuanWS/TensorflowLiteMicro",
+  "doc": "https://github.com/QingChuanWS/TensorflowLiteMicro/blob/master/README.md",
+  "readme": "a lightweight deep learning inference framework based on Google Tensorflow Lite for RT-Thread operating system.",
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://github.com/QingChuanWS/TensorflowLiteMicro.git",
+      "URL": "https://github.com/QingChuanWS/TensorflowLiteMicro/archive/v1.0.0.zip",
       "filename": "TensorflowLiteMicro-1.0.0.zip",
-      "VER_SHA": "555c14d902c1d7ebd5b6a725e931d882f42d80d6"
+      "VER_SHA": "NULL"
+    },
+    {
+      "version": "v1.0.1",
+      "URL": "https://github.com/QingChuanWS/TensorflowLiteMicro/archive/v1.0.1.zip",
+      "filename": "TensorflowLiteMicro-v1.0.1.zip",
+      "VER_SHA": "NULL"
     },
     {
       "version": "latest",
       "URL": "https://github.com/QingChuanWS/TensorflowLiteMicro.git",
-      "filename": "TensorflowLiteMicro.zip",
+      "filename": "",
       "VER_SHA": "master"
     }
   ]


### PR DESCRIPTION
修正了之前Tensorflow Lite Micro软件包对应packages路径的依赖, 同时大规模调整了工程结构, 增加了CMSIS NN优化算子, 发布了新的软件包

问题:在kconfig中,
```
config PKG_TENSORFLOWLITEMICRO_PATH
        string
        default "/packages/misc/TensorflowLiteMicro"
```
这段代码中的路径是否是软件包下载的路径呢? 如果不是那这里的路径是什么意思呢?
另外,我自己尝试下载软件包之后,其目录格式为: packages/package_name-package_version这种形式,请问目录格式是否固定呢? (因为关系到本次提交的路径依赖问题的解决情况)