### PR TITLE
add lwrb2rtt packages

### DIFF
--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -18,5 +18,6 @@ source "$PKGS_DIR/packages/tools/bs8116a/Kconfig"
 source "$PKGS_DIR/packages/tools/gps_rmc/Kconfig"
 source "$PKGS_DIR/packages/tools/UrlEncode/Kconfig"
 source "$PKGS_DIR/packages/tools/uMCN/Kconfig"
+source "$PKGS_DIR/packages/tools/lwrb2rtt/Kconfig"
 
 endmenu

--- a/tools/lwrb2rtt/Kconfig
+++ b/tools/lwrb2rtt/Kconfig
@@ -1,0 +1,36 @@
+
+# Kconfig file for package lwrb2rtt
+menuconfig PKG_USING_LWRB2RTT
+    bool "lwrb2rtt: Lightweight ring buffer manager."
+    default n
+
+if PKG_USING_LWRB2RTT
+
+    config LWRB2RTT_USING_SAMPLES
+        bool "Enable lwrb2rtt samples"
+        default n
+
+    config PKG_LWRB2RTT_PATH
+        string
+        default "/packages/tools/lwrb2rtt"
+
+    choice
+        prompt "Version"
+        default PKG_USING_LWRB2RTT_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_LWRB2RTT_V100
+            bool "v1.0.0"
+
+        config PKG_USING_LWRB2RTT_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_LWRB2RTT_VER
+       string
+       default "v1.0.0"    if PKG_USING_LWRB2RTT_V100
+       default "latest"    if PKG_USING_LWRB2RTT_LATEST_VERSION
+
+endif
+

--- a/tools/lwrb2rtt/package.json
+++ b/tools/lwrb2rtt/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "lwrb2rtt",
+  "description": "Lightweight ring buffer manager",
+  "description_zh": "轻量级的 FIFO 环形缓冲区",  
+  "enable": "PKG_USING_LWRB2RTT", 
+  "keywords": [
+    "lwrb2rtt"
+  ],
+  "category": "tools",
+  "author": {
+    "name": "Jackistang",
+    "email": "tangjia.jackis@qq.com",
+    "github": "Jackistang"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/Jackistang/lwrb2rtt",
+  "homepage": "https://github.com/Jackistang/lwrb2rtt/blob/develop/README.md",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/Jackistang/lwrb2rtt/archive/v1.0.0.zip",
+      "filename": "lwrb2rtt-v1.0.0.zip",
+      "VER_SHA": "NULL"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/Jackistang/lwrb2rtt.git",
+      "filename": "lwrb2rtt-latest",
+      "VER_SHA": "develop"
+    }
+  ]
+}


### PR DESCRIPTION
lwrb2rtt 是一个轻量级的环形缓冲区管理软件包，提供了通用的 FIFO 环形缓冲区实现。
此项目完成了开源的 lwrb 与 rt-thread 的匹配。