### PR TITLE
[peripherals][i2c-tolls] select cpp

### DIFF
--- a/peripherals/i2c-tools/Kconfig
+++ b/peripherals/i2c-tools/Kconfig
@@ -5,6 +5,7 @@ menuconfig PKG_USING_I2C_TOOLS
     select RT_USING_PIN
     select RT_USING_I2C
     select RT_USING_I2C_BITOPS
+    select RT_USING_CPLUSPLUS
     default n
 
 if PKG_USING_I2C_TOOLS


### PR DESCRIPTION
源码用了 C++，默认选中 RT_USING_CPLUSPLUS