### PR TITLE
[update] Update nuclei-sdk package version

### DIFF
--- a/peripherals/nuclei_sdk/Kconfig
+++ b/peripherals/nuclei_sdk/Kconfig
@@ -20,8 +20,8 @@ if PKG_USING_NUCLEI_SDK
         help
             Select the package version
 
-        config PKG_USING_NUCLEI_SDK_V023
-            bool "0.2.3"
+        config PKG_USING_NUCLEI_SDK_V030
+            bool "0.3.0"
 
         config PKG_USING_NUCLEI_SDK_LATEST_VERSION
             bool "latest"
@@ -29,7 +29,7 @@ if PKG_USING_NUCLEI_SDK
 
     config PKG_NUCLEI_SDK_VER
        string
-       default "0.2.3"     if PKG_USING_NUCLEI_SDK_V023
+       default "0.3.0"     if PKG_USING_NUCLEI_SDK_V030
        default "latest"    if PKG_USING_NUCLEI_SDK_LATEST_VERSION
 
 endif

--- a/peripherals/nuclei_sdk/Kconfig
+++ b/peripherals/nuclei_sdk/Kconfig
@@ -20,6 +20,9 @@ if PKG_USING_NUCLEI_SDK
         help
             Select the package version
 
+        config PKG_USING_NUCLEI_SDK_V023
+            bool "0.2.3"
+
         config PKG_USING_NUCLEI_SDK_V030
             bool "0.3.0"
 
@@ -29,6 +32,7 @@ if PKG_USING_NUCLEI_SDK
 
     config PKG_NUCLEI_SDK_VER
        string
+       default "0.2.3"     if PKG_USING_NUCLEI_SDK_V023
        default "0.3.0"     if PKG_USING_NUCLEI_SDK_V030
        default "latest"    if PKG_USING_NUCLEI_SDK_LATEST_VERSION
 

--- a/peripherals/nuclei_sdk/package.json
+++ b/peripherals/nuclei_sdk/package.json
@@ -23,10 +23,10 @@
   "doc": "https://doc.nucleisys.com/nuclei_sdk",
   "site": [
     {
-      "version": "0.2.3",
+      "version": "0.3.0",
       "URL": "https://github.com/Nuclei-Software/nuclei-sdk.git",
-      "filename": "nuclei_sdk-0.2.3.zip",
-      "VER_SHA": "0.2.3"
+      "filename": "nuclei_sdk-0.3.0.zip",
+      "VER_SHA": "0.3.0"
     },
     {
       "version": "latest",

--- a/peripherals/nuclei_sdk/package.json
+++ b/peripherals/nuclei_sdk/package.json
@@ -23,8 +23,14 @@
   "doc": "https://doc.nucleisys.com/nuclei_sdk",
   "site": [
     {
+      "version": "0.2.3",
+      "URL": "https://github.com/Nuclei-Software/nuclei-sdk/archive/0.2.3.zip",
+      "filename": "nuclei_sdk-0.2.3.zip",
+      "VER_SHA": "0.2.3"
+    },
+    {
       "version": "0.3.0",
-      "URL": "https://github.com/Nuclei-Software/nuclei-sdk.git",
+      "URL": "https://github.com/Nuclei-Software/nuclei-sdk/archive/0.3.0.zip",
       "filename": "nuclei_sdk-0.3.0.zip",
       "VER_SHA": "0.3.0"
     },


### PR DESCRIPTION
Nuclei SDK version updated from `0.2.3` -> `0.3.0`
