### PR TITLE
add cw2015 driver for RT-Thread

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -57,5 +57,5 @@ source "$PKGS_DIR/packages/peripherals/ssd1306/Kconfig"
 source "$PKGS_DIR/packages/peripherals/qkey/Kconfig"
 source "$PKGS_DIR/packages/peripherals/rs485/Kconfig"
 source "$PKGS_DIR/packages/peripherals/nes/Kconfig"
-
+source "$PKGS_DIR/packages/peripherals/cw2015/Kconfig"
 endmenu

--- a/peripherals/cw2015/Kconfig
+++ b/peripherals/cw2015/Kconfig
@@ -1,0 +1,34 @@
+
+# Kconfig file for package cw2015
+menuconfig PKG_USING_CW2015
+    bool "cw2015: fuel gauging system IC for Lithium-ion(Li+) Battery"
+    default n
+
+if PKG_USING_CW2015
+
+    config PKG_CW2015_PATH
+        string
+        default "/packages/peripherals/cw2015"
+
+    config CW2015_USE_AUTO_UPDATE
+        bool "Enable auto update battery information"
+        default n
+        help
+            "It will automatic update battery info by a thread."
+                     
+    choice
+        prompt "Version"
+        default PKG_USING_CW2015_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_CW2015_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_CW2015_VER
+       string
+       default "latest"    if PKG_USING_CW2015_LATEST_VERSION
+
+endif
+

--- a/peripherals/cw2015/package.json
+++ b/peripherals/cw2015/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cw2015",
+  "description": "fuel gauging system IC for Lithium-ion(Li+) Battery",
+  "description_zh": "电量计IC CW2015驱动软件包",
+  "enable": "PKG_USING_CW2015",
+  "keywords": [
+    "cw2015"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "qingehao",
+    "email": "qingehao@qq.com",
+    "github": "https://github.com/qingehao"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/qingehao/CW2015",
+  "homepage": "https://github.com/qingehao/CW2015",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/qingehao/CW2015.git",
+      "filename": "CW2015.zip",
+      "VER_SHA": "main"
+    }
+  ]
+}


### PR DESCRIPTION
CW2015 is an ultra-compact,host-side/pack-side,sensing resistor free,fuel gauging system IC for Li+ battery based batteries in handled and portable devices.