### PR TITLE
[ai][quest] new package quest - Quantum Computer Simulator

### DIFF
--- a/ai/Kconfig
+++ b/ai/Kconfig
@@ -7,5 +7,6 @@ source "$PKGS_DIR/packages/ai/onnx-parser/Kconfig"
 source "$PKGS_DIR/packages/ai/TensorflowLiteMicro/Kconfig"
 source "$PKGS_DIR/packages/ai/elapack/Kconfig"
 source "$PKGS_DIR/packages/ai/ulapack/Kconfig"
+source "$PKGS_DIR/packages/ai/quest/Kconfig"
 
 endmenu

--- a/ai/quest/Kconfig
+++ b/ai/quest/Kconfig
@@ -1,0 +1,47 @@
+
+# Kconfig file for package quest
+menuconfig PKG_USING_QUEST
+    select RT_USING_RTC
+    bool "quest: A simulator of quantum computers on MCU. (RTC required)"
+    default n
+
+if PKG_USING_QUEST
+
+    config PKG_QUEST_PATH
+        string
+        default "/packages/iot/quest"
+
+    config QUEST_USING_TUTORIAL_EXAMPLE
+        bool "quest: basic tutorial example."
+        help
+            quest: basic tutorial example.
+        default n
+
+    config QUEST_USING_DAMPING_EXAMPLE
+        bool "quest: damping example."
+        help
+            quest: damping example.
+        default n
+
+    config QUEST_USING_BERNSTEIN_VAZIRANI_CIRCUIT_EXAMPLE
+        bool "quest: bernstein vazirani circuit example."
+        help
+            quest: bernstein vazirani circuit example.
+        default n
+
+    choice
+        prompt "Version"
+        default PKG_USING_QUEST_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_QUEST_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_QUEST_VER
+       string
+       default "latest"    if PKG_USING_QUEST_LATEST_VERSION
+
+endif
+

--- a/ai/quest/package.json
+++ b/ai/quest/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "quest",
+  "description": "A simulator of quantum computers on MCU.",
+  "description_zh": "嵌入式系统上的量子计算机模拟器",  
+  "enable": "PKG_USING_QUEST", 
+  "keywords": [
+    "quest",
+    "quantum",
+    "simulator"
+  ],
+  "category": "iot",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@qq.com",
+    "github": "wuhanstudio"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/wuhanstudio/QuEST",
+  "icon": "https://quest.qtechtheory.org/wp-content/uploads/2018/04/chalice-100x113.png",
+  "homepage": "https://quest.qtechtheory.org/",
+  "doc": "https://quest.qtechtheory.org/",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/QuEST.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
Oxford 开源的量子计算机模拟器 (QuEST)

在 RT-Thread 上如果有 RTC 也成功运行了，虽然不知道有没有用，但是可以试试 MCU 能模拟多少个量子比特：

- 嵌入式系统：可以模拟 [ 9, ? ] qbits.
- 普通笔记本：可以模拟 20 qbits.
- GPU 笔记本：可以模拟 28 qbits.
- 服务器集群：可以模拟 45 qbits.

然而 IBM-Q 马上就有 1000 qbits 的量子计算机了.

Example: 3个量子比特电路.

```
msh />quest_tutorial
-------------------------------------------------------
Running QuEST tutorial:
         Basic circuit involving a system of 3 qubits.
-------------------------------------------------------

This is our environment:
QUBITS:
Number of qubits is 3.
Number of amps is 8.
Number of amps per rank is 8.
EXECUTION ENVIRONMENT:
Running locally on one node
Number of ranks is 1
OpenMP disabled
Precision: size of qreal is 8 bytes

Circuit output:
Probability amplitude of |111>: 0.112422
Probability of qubit 2 being in state 1: 0.749178
Qubit 0 was measured in state 1
Qubit 2 collapsed to 1 with probability 0.99451
msh />
```

Example:  一个量子比特 damping.

```
msh />quest_damping
-------------------------------------------------------
Running QuEST damping example:
         Basic circuit involving damping of a qubit.
-------------------------------------------------------

 Reporting the qubit stat to screen:
Reporting state [
real, imag
0.50000000000000, 0.00000000000000
0.50000000000000, 0.00000000000000
0.50000000000000, 0.00000000000000
0.50000000000000, 0.00000000000000
]

 Applying damping 10 times with probability 0.1 

 Qubit state after applying damping 1 times:
Reporting state [
real, imag
0.55000000000000, 0.00000000000000
0.47434164902526, 0.00000000000000
0.47434164902526, 0.00000000000000
0.45000000000000, 0.00000000000000
]
.....
```

Example: 9个量子比特一步求解 Bernstein-Vazirani.

```
msh />quest_bernstein_vazirani_circuit
solution reached with probability 1.000000
msh />
```