### PR TITLE
Peripheral nfc tools

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -63,4 +63,5 @@ source "$PKGS_DIR/packages/peripherals/vdevice/Kconfig"
 source "$PKGS_DIR/packages/peripherals/sgm706/Kconfig"
 source "$PKGS_DIR/packages/peripherals/rda58xx/Kconfig"
 source "$PKGS_DIR/packages/peripherals/libnfc/Kconfig"
+source "$PKGS_DIR/packages/peripherals/mfoc/Kconfig"
 endmenu

--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -62,4 +62,5 @@ source "$PKGS_DIR/packages/peripherals/vsensor/Kconfig"
 source "$PKGS_DIR/packages/peripherals/vdevice/Kconfig"
 source "$PKGS_DIR/packages/peripherals/sgm706/Kconfig"
 source "$PKGS_DIR/packages/peripherals/rda58xx/Kconfig"
+source "$PKGS_DIR/packages/peripherals/libnfc/Kconfig"
 endmenu

--- a/peripherals/libnfc/Kconfig
+++ b/peripherals/libnfc/Kconfig
@@ -1,0 +1,43 @@
+
+# Kconfig file for package libnfc
+menuconfig PKG_USING_LIBNFC
+    select RT_USING_LIBC
+    bool "libnfc: Platform independent Near Field Communication (NFC) library."
+    default n
+
+if PKG_USING_LIBNFC
+
+    config PKG_LIBNFC_PATH
+        string
+        default "/packages/peripherals/libnfc"
+
+    config LIBNFC_UART_NAME
+        string "serial device name"
+        default "uart2"
+
+    config LIBNFC_USING_READ_TAG_EXAMPLE
+        bool "libnfc: reading the tag example."
+        help
+            libnfc: reading the tag example.
+        default n
+
+    config DBG_ENABLE
+        bool "Enable Debug"
+        default n
+
+    choice
+        prompt "Version"
+        default PKG_USING_LIBNFC_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_LIBNFC_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_LIBNFC_VER
+       string
+       default "latest"    if PKG_USING_LIBNFC_LATEST_VERSION
+
+endif
+

--- a/peripherals/libnfc/package.json
+++ b/peripherals/libnfc/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "libnfc",
+  "description": "Platform independent Near Field Communication (NFC) library",
+  "description_zh": "libnc 软件包",  
+  "enable": "PKG_USING_LIBNFC", 
+  "keywords": [
+    "libnfc",
+    "nfc",
+    "pn532"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@qq.com",
+    "github": "wuhanstudio"
+  },
+  "license": "LGPL-3.0",
+  "repository": "https://github.com/wuhanstudio/libnfc",
+  "icon": "unknown",
+  "homepage": "unknown",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/libnfc.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}

--- a/peripherals/mfoc/Kconfig
+++ b/peripherals/mfoc/Kconfig
@@ -1,0 +1,30 @@
+
+# Kconfig file for package mfoc
+menuconfig PKG_USING_MFOC
+    select RT_USING_DFS
+    select PKG_USING_LIBNFC
+    bool "mfoc: Mifare Classic Offline Cracker."
+    default n
+
+if PKG_USING_MFOC
+
+    config PKG_MFOC_PATH
+        string
+        default "/packages/peripherals/mfoc"
+
+    choice
+        prompt "Version"
+        default PKG_USING_MFOC_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_MFOC_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_MFOC_VER
+       string
+       default "latest"    if PKG_USING_MFOC_LATEST_VERSION
+
+endif
+

--- a/peripherals/mfoc/package.json
+++ b/peripherals/mfoc/package.json
@@ -4,7 +4,10 @@
   "description_zh": "Mifare Classic 离线破解工具。",  
   "enable": "PKG_USING_MFOC", 
   "keywords": [
-    "mfoc"
+    "mfoc",
+    "libnfc",
+    "nfc",
+    "pn532"
   ],
   "category": "peripherals",
   "author": {

--- a/peripherals/mfoc/package.json
+++ b/peripherals/mfoc/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mfoc",
+  "description": "Mifare Classic Offline Cracker.",
+  "description_zh": "Mifare Classic 离线破解工具。",  
+  "enable": "PKG_USING_MFOC", 
+  "keywords": [
+    "mfoc"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@qq.com",
+    "github": "wuhanstudio"
+  },
+  "license": "GPL-2.0",
+  "repository": "https://github.com/wuhanstudio/mfoc",
+  "icon": "unknown",
+  "homepage": "unknown",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/mfoc.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
Ubuntu 下的 NFC 软件包和加密破解软件包。

- libnfc 1.7.1

```
 \ | /
- RT -     Thread Operating System
 / | \     4.0.3 build Mar 21 2021
 2006 - 2021 Copyright by rt-thread team
msh />
msh />nfc_read_tag
nfc_read_tag uses libnfc 1.7.1
NFC reader: uart2 opened
The following (NFC) ISO14443A tag was found:
    ATQA (SENS_RES): 00  04  
       UID (NFCID1): 39  e9  af  02  
      SAK (SEL_RES): 08  
msh />
```

- mfoc