### PR TITLE
解决nes软件包报错

### DIFF
--- a/peripherals/nes/Kconfig
+++ b/peripherals/nes/Kconfig
@@ -28,16 +28,12 @@ if PKG_USING_NES
         help
             Select the package version
 			
-        config PKG_USING_NES_V100
-            bool "v1.0.0"
-
         config PKG_USING_NES_LATEST_VERSION
             bool "latest"
     endchoice
           
     config PKG_NES_VER
        string
-	   default "v1.0.0"    if PKG_USING_NES_V100
        default "latest"    if PKG_USING_NES_LATEST_VERSION
 
 endif

--- a/peripherals/nes/package.json
+++ b/peripherals/nes/package.json
@@ -19,14 +19,9 @@
   "doc": "unknown",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://gitee.com/Ghazi_gq/nes/repository/archive/v1.0.0?format=zip",
-      "filename": "nes-v1.0.0.zip"
-    },
-    {
       "version": "latest",
       "URL": "https://gitee.com/Ghazi_gq/nes.git",
-      "filename": "nes.zip",
+      "filename": "Null for git package",
       "VER_SHA": "master"
     }
   ]


### PR DESCRIPTION
如果采用gitee作为第一发布源，不可以打tag版本，因为gitee在下载zip压缩包之前要有一个验证图案的步骤，导致不能获取一个固定的.zip下载地址，很坑人。建议后续如果有人采用gitee作为第一发布源，应当及时劝阻其使用github作为第一发布源。否则对国外用户也不太友好，且无法打tag。