### PR TITLE
添加ST(意法半导体)的LSM6DSM传感器驱动包

### DIFF
--- a/peripherals/sensors/Kconfig
+++ b/peripherals/sensors/Kconfig
@@ -4,7 +4,7 @@ menuconfig PKG_USING_SENSORS_DRIVERS
     select RT_USING_SENSOR
 
     if PKG_USING_SENSORS_DRIVERS
-
+        source "$PKGS_DIR/packages/peripherals/sensors/lsm6dsm/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/lsm6dsl/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/lps22hb/Kconfig"
         source "$PKGS_DIR/packages/peripherals/sensors/hts221/Kconfig"

--- a/peripherals/sensors/lsm6dsm/Kconfig
+++ b/peripherals/sensors/lsm6dsm/Kconfig
@@ -1,0 +1,61 @@
+
+# Kconfig file for package LSM6DSM
+menuconfig PKG_USING_LSM6DSM
+    bool "LSM6DSM sensor driver package, support: accelerometer, gyroscope, step, temperature."
+    default n
+
+if PKG_USING_LSM6DSM
+
+    config PKG_LSM6DSM_PATH
+        string
+        default "/packages/peripherals/sensors/lsm6dsm"
+
+    config PKG_LSM6DSM_USING_ACCE
+		bool "Enable LSM6DSM Accelerometer"
+		default y
+
+    config PKG_LSM6DSM_USING_GYRO
+		bool "Enable LSM6DSM gyro"
+		default y
+
+    config PKG_LSM6DSM_USING_STEP
+		bool "Enable LSM6DSM temperature"
+		default y
+
+    config PKG_LSM6DSM_USING_TEMP
+		bool "Enable LSM6DSM step count"
+		default y
+
+    choice
+        prompt "I2C device address type"
+        default PKG_LSM6DSM_I2C_ADDR_TYPE_LOW
+        help
+            Select I2C device address type: if SA0=0 -> I2C_DEVICE_TYPE_LOW if SA0=1 -> I2C_DEVICE_TYPE_HIGH
+
+        config PKG_LSM6DSM_I2C_ADDR_TYPE_HIGH
+            bool "I2C address high. if SA0 pad connect to VCC, select me"
+
+        config PKG_LSM6DSM_I2C_ADDR_TYPE_LOW
+            bool "I2C address low. if SA0 pad connect to GND, select me"
+    endchoice
+
+    choice
+        prompt "Version"
+        default PKG_USING_LSM6DSM_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_LSM6DSM_V100
+            bool "v1.0.0"
+
+        config PKG_USING_LSM6DSM_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_LSM6DSM_VER
+       string
+       default "v1.0.0"    if PKG_USING_LSM6DSM_V100
+       default "latest"    if PKG_USING_LSM6DSM_LATEST_VERSION
+
+endif
+

--- a/peripherals/sensors/lsm6dsm/package.json
+++ b/peripherals/sensors/lsm6dsm/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "lsm6dsm",
+  "description": "STMicroelectronics's LSM6DSM driver,support Accelerometer/gyro/step count/temperature",
+  "description_zh": "STMicroelectronics的LSM6DSM传感器驱动，支持加速度计/陀螺仪/计步/温度",  
+  "enable": "PKG_USING_LSM6DSM", 
+  "keywords": [
+    "lsm6dsm"
+  ],
+  "category": "peripherals/sensors",
+  "author": {
+    "name": "zcj20080882",
+    "email": "zcj20080882@otlook.com",
+    "github": "zcj20080882"
+  },
+  "license": "MIT",
+  "repository": "https://gitee.com/my-rt-packages/lsm6dsm.git",
+  "icon": "unknown",
+  "homepage": "unknown",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://gitee.com/my-rt-packages/lsm6dsm/repository/archive/v1.0.0?format=zip",
+      "filename": "lsm6dsm-1.0.0.zip"
+    },
+    {
+      "version": "latest",
+      "URL": "https://gitee.com/my-rt-packages/lsm6dsm.git",
+      "filename": "Null for git package"
+    }
+  ]
+}


### PR DESCRIPTION

### 1.1 LSM6DSM传感器简介
LSM6DSM是STMicroelectronics推出的iNEMO 6DoF惯性测量单元（IMU），用于具有OIS / EIS和AR/VR系统的智能手机。超低功耗、高精度和稳定性，配备 3D 数字加速度计和 3D 数字陀螺仪，在高性能模式下以 0.65 mA 的速度工作，并始终启用低功耗功能，为消费者提供最佳的运动体验。

详细参考：[https://www.st.com/zh/mems-and-sensors/lsm6dsm.html](https://www.st.com/zh/mems-and-sensors/lsm6dsm.html)

### 1.2 功能介绍

- 通讯接口
  - [x] I2C
  - [ ] SPI

- 支持的功能
  - [x] 加速度计
  - [x] 陀螺仪
  - [x] 计步
  - [x] 温度
  
  **适配情况**

  | 功能         | 加速度计 | 陀螺仪 | 计步 | 温度 |
  | ---------------- | -------- | ------ | ------ | ------ |
  | **工作模式**     |          |        |        |        |
  | 轮询             | √        | √      | √      | √ |
  | 中断             |          |        |        |        |
  | FIFO             |          |        |        |        |
  | **电源模式**     |          |        |        |        |
  | 掉电             | √        | √      | √（加速度计掉电） | √（加速度计掉电） |
  | 低功耗           | √ | √ | √（加速度计低功耗） | √（加速度计低功耗） |
  | 普通             | √        | √      | √      | √ |
  | 高性能       | √        | √      | √（加速度计高性能） | √（加速度计高性能） |
  | **数据输出速率** | √        | √      |  |  |
  | **测量范围**     | √        | √      |        |        |
  
  **注意：当开启计步后，加速计数据输出速率被强制到26Hz**

### 1.3 目录结构


| 名称 | 说明 |
| ---- | ---- |
| drivers  | ST（意法半导体）提供的LSM6DSM通用C版本驱动库 |


### 1.4 许可证

遵循 Apache license v2.0 许可，详见 `LICENSE` 文件。

### 1.5 依赖

- RT-Thread 4.0+
- I2C驱动
- RT-Thread传感器驱动框架