### PR TITLE
[peripherals][kobuki] add get odometry example

### DIFF
--- a/peripherals/kobuki/Kconfig
+++ b/peripherals/kobuki/Kconfig
@@ -15,6 +15,12 @@ if PKG_USING_KOBUKI
         string "kobuki serial port"
         default "uart2"
 
+    config KOBUKI_USING_GET_odometr_EXAMPLE
+        bool "kobuki_get_odometry: get kobuki odometry (x, y, theta, v_x, v_theta)"
+        help
+            kobuki_get_odometry: get kobuki odometry (x, y, theta, v_x, v_theta)
+        default n
+
     config KOBUKI_USING_GET_VERSION_EXAMPLE
         bool "kobuki_get_version: get kobuki firmware and hardware version and uuid."
         help


### PR DESCRIPTION
现在应当不需要树莓派，只用 RT-Thread 就可以造一个 ROS 机器人小车了

- Kobuki 软件包可以发布 /odometry 定位
- rplidar 软件包可以发布 /scan 激光雷达
- rosserial 软件包可以 UART/TCP 和 ROS 通信

