### PR TITLE
[peripherals][micro_ros] new package micro_ros

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -68,4 +68,5 @@ source "$PKGS_DIR/packages/peripherals/mfoc/Kconfig"
 source "$PKGS_DIR/packages/peripherals/tmc51xx/Kconfig"
 source "$PKGS_DIR/packages/peripherals/tca9534/Kconfig"
 source "$PKGS_DIR/packages/peripherals/kobuki/Kconfig"
+source "$PKGS_DIR/packages/peripherals/micro_ros/Kconfig"
 endmenu

--- a/peripherals/micro_ros/Kconfig
+++ b/peripherals/micro_ros/Kconfig
@@ -1,0 +1,48 @@
+
+# Kconfig file for package micro_ros
+menuconfig PKG_USING_MICRO_ROS
+    bool "micro_ros: ROS 2 on microcontrollers."
+    default n
+
+if PKG_USING_MICRO_ROS
+
+    config PKG_MICRO_ROS_PATH
+        string
+        default "/packages/peripherals/micro_ros"
+
+    choice
+        prompt "Device type"
+        default MICRO_ROS_USE_SERIAL
+
+        config MICRO_ROS_USE_SERIAL
+            bool "UART"
+    endchoice
+
+    if MICRO_ROS_USE_SERIAL
+        config MICRO_ROS_SERIAL_NAME
+        string "serial device name"
+        default "uart2"
+    endif
+
+    config MICRO_ROS_USING_PUB_INT32
+        bool "microros_pub_int32: microros publish int32 example"
+        help
+            microros publish int32 example
+        default n
+
+    choice
+        prompt "Version"
+        default PKG_USING_MICRO_ROS_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_MICRO_ROS_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_MICRO_ROS_VER
+       string
+       default "latest"    if PKG_USING_MICRO_ROS_LATEST_VERSION
+
+endif
+

--- a/peripherals/micro_ros/package.json
+++ b/peripherals/micro_ros/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "micro_ros",
+  "description": "ROS 2 on microcontrollers.",
+  "description_zh": "在 MCU 上运行 ROS2.",  
+  "enable": "PKG_USING_MICRO_ROS", 
+  "keywords": [
+    "micro_ros",
+    "uart",
+    "udp",
+    "ros",
+    "ros2"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@qq.com",
+    "github": "wuhanstudio"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/wuhanstudio/micro_ros",
+  "icon": "unknown",
+  "homepage": "unknown",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/micro_ros.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
MicroROS 在 RTT 的移植: https://micro.ros.org/

这下 ROS1 (rosserial) 和 ROS2 (uROS) 都支持了。

