### PR TITLE
[peripherals][micro_ros] add more examples

### DIFF
--- a/peripherals/micro_ros/Kconfig
+++ b/peripherals/micro_ros/Kconfig
@@ -62,6 +62,43 @@ if PKG_USING_MICRO_ROS
         default n
     endif
 
+    config MICRO_ROS_USING_SUB_INT32
+        bool "microros_sub_int32: micro ros subscribe int32 example"
+        help
+            microros_sub_int32: micro ros subscribe int32 example
+        default n
+
+    config MICRO_ROS_USING_SUB_TWIST
+        bool "microros_sub_twist: micro ros subscribe to twist example"
+        help
+            microros_sub_twist, micro ros subscribe to twist example
+        default n
+
+    config MICRO_ROS_USING_ADD_INTS_SERVICE
+        bool "microros_add_ints_service: micro ros add ints service example"
+        help
+            microros_add_ints_service, micro ros add ints service example
+        default n
+
+    config MICRO_ROS_USING_DEINITIALIZATION
+        bool "microros_deinitialization: micro ros deinitialization example"
+        help
+            microros_deinitialization, micro ros deinitialization example
+        default n
+
+    config MICRO_ROS_USING_KOBUKI_CONTROL
+        select PKG_USING_KOBUKI
+        bool "microros_kobuki_control, micro ros control kobuki robot example"
+        help
+            microros_kobuki_control, micro ros control kobuki robot example
+        default n
+
+    if MICRO_ROS_USING_KOBUKI_CONTROL
+        config KOBUKI_SERIAL_NAME
+                string "kobuki serial port"
+                default "uart2"
+    endif
+
     choice
         prompt "Version"
         default PKG_USING_MICRO_ROS_LATEST_VERSION

--- a/peripherals/micro_ros/Kconfig
+++ b/peripherals/micro_ros/Kconfig
@@ -101,17 +101,20 @@ if PKG_USING_MICRO_ROS
 
     choice
         prompt "Version"
-        default PKG_USING_MICRO_ROS_LATEST_VERSION
+        default PKG_USING_MICRO_ROS_FOXY
         help
             Select the package version
 
-        config PKG_USING_MICRO_ROS_LATEST_VERSION
-            bool "latest"
+        config PKG_USING_MICRO_ROS_FOXY
+            bool "foxy"
+
+        config PKG_USING_MICRO_ROS_GALACTIC
+            bool "galactic"
     endchoice
           
     config PKG_MICRO_ROS_VER
        string
-       default "latest"    if PKG_USING_MICRO_ROS_LATEST_VERSION
+       default "foxy"    if PKG_USING_MICRO_ROS_FOXY
 
 endif
 

--- a/peripherals/micro_ros/package.json
+++ b/peripherals/micro_ros/package.json
@@ -23,10 +23,16 @@
   "doc": "unknown",
   "site": [
     {
-      "version": "latest",
+      "version": "foxy",
       "URL": "https://github.com/wuhanstudio/micro_ros.git",
       "filename": "",
-      "VER_SHA": "master"
+      "VER_SHA": "foxy"
+    },
+    {
+      "version": "galactic",
+      "URL": "https://github.com/wuhanstudio/micro_ros.git",
+      "filename": "",
+      "VER_SHA": "galactic"
     }
   ]
 }


### PR DESCRIPTION
- ROS2 (micro_ros) 增加 5 个例程：

  - micro_ros_sub_int32: 订阅 INT32 topic
  - micro_ros_sub_twist: 订阅 cmd_vel topic
  - micro_ros_add_ints_service: 发布加法 service
  - micro_ros_deinitialization: 删除节点
  - micro_ros_kobuki_control: 控制 kobuki 机器人

- 增加 ROS2 Galactic 支持
  - 默认使用 Foxy
  - 默认使用 serial 
