### PR TITLE
[rt_memcpy_cm] 增加RT_USING_ASM_MEMCPY宏定义

### DIFF
--- a/system/acceleration/rt_memcpy_cm/Kconfig
+++ b/system/acceleration/rt_memcpy_cm/Kconfig
@@ -2,6 +2,7 @@
 # Kconfig file for package rt_memcpy_cm
 menuconfig PKG_USING_RT_MEMCPY_CM
     bool "rt_memcpy_cm: Cortex-M kernel assembly accelerated version of rt_memcpy function"
+    select RT_USING_ASM_MEMCPY
     default n
 
 if PKG_USING_RT_MEMCPY_CM


### PR DESCRIPTION
选定本软件包后自动定义RT_USING_ASM_MEMCPY，用于通知其他程序可以使用加速版本的memcpy