### PR TITLE
将cmatrix从mcurses软件包移除，后续会独立出一个软件包

### DIFF
--- a/misc/entertainment/Kconfig
+++ b/misc/entertainment/Kconfig
@@ -1,12 +1,12 @@
 menu "entertainment: terminal games and other interesting software packages"
 
 source "$PKGS_DIR/packages/misc/entertainment/sl/Kconfig"
+source "$PKGS_DIR/packages/misc/entertainment/cal/Kconfig"
+source "$PKGS_DIR/packages/misc/entertainment/aclock/Kconfig"
 source "$PKGS_DIR/packages/misc/entertainment/threes/Kconfig"
 source "$PKGS_DIR/packages/misc/entertainment/c2048/Kconfig"
 source "$PKGS_DIR/packages/misc/entertainment/snake/Kconfig"
 source "$PKGS_DIR/packages/misc/entertainment/tetris/Kconfig"
 source "$PKGS_DIR/packages/misc/entertainment/donut/Kconfig"
-source "$PKGS_DIR/packages/misc/entertainment/aclock/Kconfig"
-source "$PKGS_DIR/packages/misc/entertainment/cal/Kconfig"
 
 endmenu

--- a/misc/mcurses/Kconfig
+++ b/misc/mcurses/Kconfig
@@ -22,12 +22,6 @@ if PKG_USING_MCURSES
             mcurses: box animation demo
         default n
 
-    config MCURSES_USING_MATRIX_RAIN
-        bool "mcurses: magic matrix rain demo"
-        help
-            mcurses: magic matrix rain demo
-        default n
-
     config MCURSES_USING_SCREEN
         bool "mcurses: screen animation demo"
         help


### PR DESCRIPTION
重新整理了一下entertainment下软件包的排序，人们在linux耳熟能详的或者是有些实际功能的放在前面，游戏什么的放在后面。
entertainment下的软件包对于软件工程开发虽然没有什么用，但是对于初学者趣味化体验rtt操作系统以及rtt软件包生态非常重要。是rtt海外推广时的一个重要部分。