### PR TITLE
Add MCUboot package

### DIFF
--- a/system/Kconfig
+++ b/system/Kconfig
@@ -35,5 +35,6 @@ source "$PKGS_DIR/packages/system/tlsf/Kconfig"
 source "$PKGS_DIR/packages/system/event_recorder/Kconfig"
 source "$PKGS_DIR/packages/system/Arm-2D/Kconfig"
 source "$PKGS_DIR/packages/system/wcwidth/Kconfig"
+source "$PKGS_DIR/packages/system/mcuboot/Kconfig"
 
 endmenu

--- a/system/mcuboot/Kconfig
+++ b/system/mcuboot/Kconfig
@@ -1,0 +1,49 @@
+
+# Kconfig file for package mcuboot
+menuconfig PKG_USING_MCUBOOT
+    bool "A common infrastructure for bootloader, system flash layout."
+    default n
+
+if PKG_USING_MCUBOOT
+
+    config PKG_MCUBOOT_PATH
+        string
+        default "/packages/system/mcuboot"
+
+    choice
+        prompt "Version"
+        default PKG_USING_MCUBOOT_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_MCUBOOT_V180
+            bool "v1.8.0"
+
+        config PKG_USING_MCUBOOT_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_MCUBOOT_VER
+       string
+       default "v1.8.0"    if PKG_USING_MCUBOOT_V180
+       default "latest"    if PKG_USING_MCUBOOT_LATEST_VERSION
+
+    menuconfig MCUBOOT_FLASH_DEVICE_USE
+    bool "MCUboot flash device choose"
+    default y
+    if MCUBOOT_FLASH_DEVICE_USE
+        config MCUBOOT_FLASH_DEVICE_W25Q
+            bool "w25qxx qspi flash as mcuboot device"
+            default y
+    endif
+    config MCUBOOT_FLASH_DEVICE_ID
+        int "flash device id"
+        default 1
+    config MCUBOOT_FLASH_SECTOR_SIZE
+        int "flash erase sector size"
+        default 4096
+    config MCUBOOT_IMAGE_SLOT_SECTOR_COUNTS
+        int "sectors counts of image slot"
+        default 64
+endif
+

--- a/system/mcuboot/package.json
+++ b/system/mcuboot/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "mcuboot",
+  "description": "A common infrastructure for the bootloader, system flash layout on microcontroller systems.",
+  "description_zh": "一个针对微控制器的涉及 bootloader, flash layout 的通用框架。",  
+  "enable": "PKG_USING_MCUBOOT", 
+  "keywords": [
+    "mcuboot"
+  ],
+  "category": "system",
+  "author": {
+    "name": "iysheng",
+    "email": "iysheng@163.com",
+    "github": "iysheng"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/iysheng/rt_mcuboot.git",
+  "icon": "unknown",
+  "homepage": "https://github.com/iysheng/rt_mcuboot.git#README",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.8.0",
+      "URL": "https://github.com/iysheng/rt_mcuboot/archive/refs/tags/v1.8.0.zip",
+      "filename": "mcuboot-1.8.0.zip",
+      "VER_SHA": "NULL"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/iysheng/rt_mcuboot.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
添加 mcuboot 的测试 demo package.在 ART-PI 测试可以实现:
*  image 的格式识别,以及在 primary slot 的跳转
*  iamge 从 secondray slot 以 MCUBOOT_OVERWRITE_ONLY 模式更新到 primary slot.
* 支持对 image  RSA 2048 格式打签以及识别
测试视频:
![](https://s3.bmp.ovh/imgs/2021/09/412d9501b4573323.gif)
配置截图:
![](https://s3.bmp.ovh/imgs/2021/09/a888954aad03b854.png)