### PR TITLE
[peripherals][i2c-tools] select libc

### DIFF
--- a/peripherals/i2c-tools/Kconfig
+++ b/peripherals/i2c-tools/Kconfig
@@ -3,6 +3,7 @@
 menuconfig PKG_USING_I2C_TOOLS
     bool "i2c-tools: a collection of i2c tools including scan/read/write"
     select RT_USING_PIN
+    select RT_USING_LIBC
     select RT_USING_I2C
     select RT_USING_I2C_BITOPS
     select RT_USING_CPLUSPLUS


### PR DESCRIPTION
RT-Thread Studio 里如果 i2c-tools 没有使用 libc 链接会报错.