### PR TITLE
新增御坂网络AT24CXX驱动

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -71,4 +71,5 @@ source "$PKGS_DIR/packages/peripherals/rosserial/Kconfig"
 source "$PKGS_DIR/packages/peripherals/micro_ros/Kconfig"
 source "$PKGS_DIR/packages/peripherals/mcp23008/Kconfig"
 source "$PKGS_DIR/packages/peripherals/bluetrum_sdk/Kconfig"
+source "$PKGS_DIR/packages/peripherals/Misaka_AT24CXX/Kconfig"
 endmenu

--- a/peripherals/Misaka_AT24CXX/Kconfig
+++ b/peripherals/Misaka_AT24CXX/Kconfig
@@ -1,0 +1,32 @@
+
+# Kconfig file for package Misaka_AT24CXX
+menuconfig PKG_USING_MISAKA_AT24CXX
+    bool "Misaka-Network for AT24CXX EEPROM"
+    default n
+
+if PKG_USING_MISAKA_AT24CXX
+
+    config PKG_USING_MISAKA_AT24CXX_DEMO
+        bool "Use demo"
+        default n
+
+    config PKG_MISAKA_AT24CXX_PATH
+        string
+        default "/packages/peripherals/Misaka_AT24CXX"
+
+    choice
+        prompt "Version"
+        default PKG_USING_MISAKA_AT24CXX_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_MISAKA_AT24CXX_V100
+            bool "1.0.0"
+    endchoice
+          
+    config PKG_MISAKA_AT24CXX_VER
+       string
+       default "1.0.0"    if PKG_USING_MISAKA_AT24CXX_V100
+
+endif
+

--- a/peripherals/Misaka_AT24CXX/package.json
+++ b/peripherals/Misaka_AT24CXX/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "Misaka_AT24CXX",
+  "description": "Misaka-Network for AT24CXX EEPROM",
+  "description_zh": "御坂网络AT24CXX驱动包，提供了AT24CXX的全部功能",  
+  "enable": "PKG_USING_MISAKA_AT24CXX", 
+  "keywords": [
+    "at24cxx",
+    "御坂",
+    "御坂网络",
+    "Misaka"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "xqyjlj",
+    "email": "xqyjlj@126.com",
+    "github": "xqyjlj"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/xqyjlj/Miaska_AT24CXX",
+  "icon": "unknown",
+  "homepage": "https://github.com/xqyjlj/Miaska_AT24CXX",
+  "doc": "https://xqyjlj.github.io/2021/05/15/%E5%BE%A1%E5%9D%82%E7%BD%91%E7%BB%9C%E9%A9%B1%E5%8A%A8-AT24CXX/",
+  "site": [
+    {
+      "version": "1.0.0",
+      "URL": "https://github.com/xqyjlj/Miaska_AT24CXX/archive/1.0.0.zip",
+      "filename": "Miaska_AT24CXX-1.0.0.zip",
+      "VER_SHA": "68f344634ad316e9ac029bff03d1f88a7a8f9e54"
+    }
+  ]
+}


### PR DESCRIPTION
原有的AT24CXX不带页写算法，原版主也联系不上了，干脆自己补充一个好了