### PR TITLE
[peripherals][rosserial] select libc

### DIFF
--- a/peripherals/rosserial/Kconfig
+++ b/peripherals/rosserial/Kconfig
@@ -3,6 +3,7 @@
 menuconfig PKG_USING_ROSSERIAL
     bool "rosserial: ROS 1 on microcontrollers."
     select RT_USING_CPLUSPLUS
+    select RT_USING_LIBC
     default n
 
 if PKG_USING_ROSSERIAL


### PR DESCRIPTION
突然发现，以前写的软件包很多软件包都没有选择 libc，导致编译报错。