### PR TITLE
[multimedia][u8g2] Remove legacy version

### DIFF
--- a/multimedia/u8g2/u8g2-official/Kconfig
+++ b/multimedia/u8g2/u8g2-official/Kconfig
@@ -86,7 +86,7 @@ if PKG_USING_U8G2_OFFICIAL
                 Print "Hello RT-Thread" on ST7920 LCD using 8080 mode
             default n
 
-        if (PKG_U8G2_VER_NUM > 0x20000 && PKG_U8G2_VER_NUM < 0x30000) || (PKG_U8G2_VER_NUM >= 0x30000 && U8G2_USE_CPP)
+        if (U8G2_USE_CPP)
             menu "full buffer examples    (fast, large RAM consumption)"
                 config U8G2_USING_FRAME_EXAMPLE_FONT_USAGE
                     bool "Font Usage        : How to overwrite previous text with a new text"


### PR DESCRIPTION
Upstream 的 u8g2 不需要判断以前软件包的版本号了，忘记删掉了。