### PR TITLE
[fix] 在没有释出版本之前，ota_downloader 的最新代码应该匹配 webclient 的最新代码，因为引用了 webclient 中最新实现的一个函数。

### DIFF
--- a/iot/webclient/Kconfig
+++ b/iot/webclient/Kconfig
@@ -16,7 +16,7 @@ if PKG_USING_WEBCLIENT
             default n
 
         config WEBCLIENT_USING_SAMPLES
-            bool "Enable webclient GET/POST samples"
+            bool "Enable webclient GET/POST/SHARD samples"
             default n
 
     endif
@@ -66,8 +66,9 @@ if PKG_USING_WEBCLIENT
         prompt "Version"
         help
             Select the webclient version
+        default PKG_USING_WEBCLIENT_LATEST_VERSION if PKG_USING_OTA_DOWNLOADER_LATEST_VERSION
         default PKG_USING_WEBCLIENT_V212
-        
+
         config PKG_USING_WEBCLIENT_V212
             bool "v2.1.2"
 


### PR DESCRIPTION
you should choose the laster of "webclient" when you choose the laster of "ota_downloader".

https://github.com/RT-Thread-packages/webclient/pull/76