### PR TITLE
[tools/fdt] update version 1.0.0

### DIFF
--- a/tools/fdt/package.json
+++ b/tools/fdt/package.json
@@ -21,7 +21,7 @@
       "version": "v1.0.0",
       "URL": "https://github.com/RT-Thread-packages/fdt.git",
       "filename": "fdt-1.0.0.zip",
-      "VER_SHA": "3b647cc1f534271f58ee3a19bad8a872f350f370"
+      "VER_SHA": "3d4bc19375e22100caecacdbc146190484d94a24"
     },
     {
       "version": "latest",


### PR DESCRIPTION
重新指定v1.0.0,并确定为dfs_posix接口兼容版本,往后版本都将为使用posix接口版本