### PR TITLE
[security] Add package libhydrogen

### DIFF
--- a/security/Kconfig
+++ b/security/Kconfig
@@ -2,6 +2,7 @@ menu "security packages"
 
 source "$PKGS_DIR/packages/security/mbedtls/Kconfig"
 source "$PKGS_DIR/packages/security/libsodium/Kconfig"
+source "$PKGS_DIR/packages/security/libhydrogen/Kconfig"
 source "$PKGS_DIR/packages/security/tinycrypt/Kconfig"
 source "$PKGS_DIR/packages/security/trusted-firmware-m/Kconfig"
 source "$PKGS_DIR/packages/security/yd_crypto/Kconfig"

--- a/security/libhydrogen/Kconfig
+++ b/security/libhydrogen/Kconfig
@@ -1,0 +1,31 @@
+
+# Kconfig file for package libhydrogen
+menuconfig PKG_USING_LIBHYDROGEN
+    bool "libhydrogen: A lightweight, secure, easy-to-use crypto library suitable for constrained environments."
+    select RT_USING_HWCRYPTO
+    select RT_HWCRYPTO_USING_RNG
+    select RT_USING_LIBC if RT_VER_NUM < 0x40100
+    default n
+
+if PKG_USING_LIBHYDROGEN
+
+    config PKG_LIBHYDROGEN_PATH
+        string
+        default "/packages/security/libsodium"
+
+    choice
+        prompt "Version"
+        default PKG_USING_LIBHYDROGEN_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_LIBHYDROGEN_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_LIBHYDROGEN_VER
+       string
+       default "latest"    if PKG_USING_LIBHYDROGEN_LATEST_VERSION
+
+endif
+

--- a/security/libhydrogen/package.json
+++ b/security/libhydrogen/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "libhydrogen",
+  "description": "A lightweight, secure, easy-to-use crypto library suitable for constrained environments.",
+  "description_zh": "一个轻量级，易用，适合嵌入式的密码学软件包",
+  "enable": "PKG_USING_LIBHYDROGEN",
+  "keywords": [
+    "libhydrogen",
+    "crypto"
+  ],
+  "category": "security",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudio@qq.com",
+    "github": "wuhanstudio"
+  },
+  "license": "ISC",
+  "repository": "https://github.com/wuhanstudio/libhydrogen",
+  "icon": "https://www.rt-thread.org/qa/template/fxiaomi/style/image/logo.png",
+  "homepage": "https://github.com/wuhanstudio/libhydrogen#readme",
+  "readme": "A lightweight, secure, easy-to-use crypto library suitable for constrained environments.",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/libhydrogen.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
之前移植 `libsodium` 的时候，感觉它更适合 unix 系列，`libhydrogen` 更适合嵌入式

- Add crypto library [libhydrogen](https://github.com/jedisct1/libhydrogen)

![image](https://user-images.githubusercontent.com/15157070/167179926-678c7b3b-f908-47a5-a684-6dc46b6aaeeb.gif)
