### PR TITLE
[misc] Add package slcan2rtt

### DIFF
--- a/misc/Kconfig
+++ b/misc/Kconfig
@@ -33,5 +33,6 @@ source "$PKGS_DIR/packages/misc/design_pattern/Kconfig"
 source "$PKGS_DIR/packages/misc/Controller/Kconfig"
 source "$PKGS_DIR/packages/misc/phase-locked-loop/Kconfig"
 source "$PKGS_DIR/packages/misc/MFBD/Kconfig"
+source "$PKGS_DIR/packages/misc/slcan2rtt/Kconfig"
 
 endmenu

--- a/misc/slcan2rtt/Kconfig
+++ b/misc/slcan2rtt/Kconfig
@@ -16,8 +16,8 @@ if PKG_USING_SLCAN2RTT
         help
             Select the package version
 
-        config PKG_USING_SLCAN2RTT_V100
-            bool "v1.0.0"
+        config PKG_USING_SLCAN2RTT_V001
+            bool "v0.0.1"
 
         config PKG_USING_SLCAN2RTT_LATEST_VERSION
             bool "latest"
@@ -25,7 +25,7 @@ if PKG_USING_SLCAN2RTT
           
     config PKG_SLCAN2RTT_VER
        string
-       default "v1.0.0"    if PKG_USING_SLCAN2RTT_V100
+       default "v0.0.1"    if PKG_USING_SLCAN2RTT_V001
        default "latest"    if PKG_USING_SLCAN2RTT_LATEST_VERSION
 
 endif

--- a/misc/slcan2rtt/Kconfig
+++ b/misc/slcan2rtt/Kconfig
@@ -1,0 +1,32 @@
+
+# Kconfig file for package slcan2rtt
+menuconfig PKG_USING_SLCAN2RTT
+    bool "Serial / USB serial CAN Adapter (slcan) on RT-Thread."
+    default n
+
+if PKG_USING_SLCAN2RTT
+
+    config PKG_SLCAN2RTT_PATH
+        string
+        default "/packages/misc/slcan2rtt"
+
+    choice
+        prompt "Version"
+        default PKG_USING_SLCAN2RTT_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_SLCAN2RTT_V100
+            bool "v1.0.0"
+
+        config PKG_USING_SLCAN2RTT_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_SLCAN2RTT_VER
+       string
+       default "v1.0.0"    if PKG_USING_SLCAN2RTT_V100
+       default "latest"    if PKG_USING_SLCAN2RTT_LATEST_VERSION
+
+endif
+

--- a/misc/slcan2rtt/package.json
+++ b/misc/slcan2rtt/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "slcan2rtt",
+  "description": "Serial / USB serial CAN Adapter (slcan) on RT-Thread.",
+  "description_zh": "串行线路CAN适配器 (slcan).",
+  "enable": "PKG_USING_SLCAN2RTT", 
+  "keywords": [
+    "slcan2rtt",
+    "slcan",
+    "usb2can",
+    "can" ,
+    "serial" 
+  ],
+  "category": "misc",
+  "author": {
+    "name": "cazure",
+    "email": "chenbin182@qq.com",
+    "github": "cazure"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/cazure/slcan2rtt.git",
+  "icon": "unknown",
+  "homepage": "unknown",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/cazure/slcan2rtt.git",
+      "filename": "slcan2rtt-1.0.0.zip",
+      "VER_SHA": "master"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/cazure/slcan2rtt.git",
+      "filename": "slcan2rtt-master.zip",
+      "VER_SHA": "master"
+    }
+  ]
+}

--- a/misc/slcan2rtt/package.json
+++ b/misc/slcan2rtt/package.json
@@ -23,10 +23,10 @@
   "doc": "unknown",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/cazure/slcan2rtt.git",
-      "filename": "slcan2rtt-1.0.0.zip",
-      "VER_SHA": "master"
+      "version": "v0.0.1",
+      "URL": "https://github.com/cazure/slcan2rtt/archive/refs/tags/v0.0.1.zip",
+      "filename": "slcan2rtt-v0.0.1.zip",
+      "VER_SHA": "cc374f858145a9b4294dcc73f03b1b31b64c1dae"
     },
     {
       "version": "latest",


### PR DESCRIPTION
 Add package slcan2rtt
这是一个在 RT-Thread 上，用于实现slcan协议的软件包 。基于RT-Thread的device框架实现 can和serial端口的数据转换功能。