### PR TITLE
[security][libhydrogen] Add rng and hash examples

### DIFF
--- a/security/libhydrogen/Kconfig
+++ b/security/libhydrogen/Kconfig
@@ -13,6 +13,22 @@ if PKG_USING_LIBHYDROGEN
         string
         default "/packages/security/libsodium"
 
+    menu "Examples"
+
+        config LIBHYDROGEN_USING_EXAMPLE_RANDOM
+            bool "hydrogen rng: returns unpredictable values."
+            help
+                hydrogen rng: returns unpredictable values.
+            default n
+
+        config LIBHYDROGEN_USING_EXAMPLE_GENERIC_HASH
+            bool "hydrogen generic hash: transforms an arbitrary-long input into a fixed length fingerprint."
+            help
+                hydrogen generic hash: transforms an arbitrary-long input into a fixed length fingerprint.
+            default n
+
+    endmenu
+
     choice
         prompt "Version"
         default PKG_USING_LIBHYDROGEN_LATEST_VERSION


### PR DESCRIPTION
libhydrogen 添加几个基本例程：

- 添加随机数例程 u32, uniform
- 添加 short hash 例程
