### PR TITLE
[security][libsodium] legacy - use libhydrogen instead

### DIFF
--- a/security/libsodium/Kconfig
+++ b/security/libsodium/Kconfig
@@ -1,7 +1,7 @@
 
 # Kconfig file for package libsodium
 menuconfig PKG_USING_LIBSODIUM
-    bool "libsodium: A modern and easy-to-use crypto library."
+    bool "libsodium: A modern and easy-to-use crypto library (NOT Recommended for MCU. Use libhydrogen instead)."
     default n
 
 if PKG_USING_LIBSODIUM

--- a/security/libsodium/package.json
+++ b/security/libsodium/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libsodium",
-  "description": "A modern and easy-to-use crypto library",
-  "description_zh": "一个现代的、易用的加密库",
+  "description": "A modern and easy-to-use crypto library (NOT Recommended for MCU. Use libhydrogen instead).",
+  "description_zh": "一个现代的、易用的加密库 (不推荐在 MCU 上使用，请用 libhydrogen 替代).",
   "enable": "PKG_USING_LIBSODIUM",
   "keywords": [
     "libsodium",
@@ -14,14 +14,14 @@
     "github": "RT-Thread-packages"
   },
   "license": "ISC",
-  "repository": "https://github.com/RT-Thread-packages/libsodium",
+  "repository": "https://github.com/RT-Thread-packages/libsodium-legacy",
   "icon": "https://www.rt-thread.org/qa/template/fxiaomi/style/image/logo.png",
-  "homepage": "https://github.com/RT-Thread-packages/libsodium#readme",
+  "homepage": "https://github.com/RT-Thread-packages/libsodium-legacy#readme",
   "readme": "A modern and easy-to-use crypto library.",
   "site": [
     {
       "version": "latest",
-      "URL": "https://github.com/RT-Thread-packages/libsodium.git",
+      "URL": "https://github.com/RT-Thread-packages/libsodium-legacy.git",
       "filename": "",
       "VER_SHA": "master"
     }


### PR DESCRIPTION
最近移植完 libhydrogen，发现 libsodium 并不适合 MCU。

- 官方文档不建议在 Cortex-M0 M3 M4 的 CPU 上运行 https://doc.libsodium.org/installation#cross-compiling
- 安全的随机数生成器 CSPRNG 在 MCU 上没有经过完整的测试
- 整体代码设计都是针对 unix 系统
- 原作者发布了适合 MCU 的版本 libhydrogen

因此在 MCU 上跑 libsodium 可能会带来安全隐患，建议使用 libhydrogen 替代

刚好昨天阿满把 libsodium-legacy 仓库设置为 archive 了。