### PR TITLE
LVGL: allow selecting stable v8.2.0 version

### DIFF
--- a/multimedia/LVGL/LVGL/Kconfig
+++ b/multimedia/LVGL/LVGL/Kconfig
@@ -10,6 +10,30 @@ if PKG_USING_LVGL
         string
         default "/packages/multimedia/LVGL/LVGL"
 
+    choice
+        prompt "Version"
+        default PKG_USING_LVGL_LATEST_VERSION
+        default PKG_USING_LVGL_V820     if RT_VER_NUM = 0x40100
+        help
+            Select the package version
+
+        config PKG_USING_LVGL_V820
+            bool "v8.2.0"
+
+        config PKG_USING_LVGL_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_LVGL_VER
+       string
+       default "v8.2.0"    if PKG_USING_LVGL_V820
+       default "latest"    if PKG_USING_LVGL_LATEST_VERSION
+
+    config PKG_LVGL_VER_NUM
+        hex
+        default 0x08020    if PKG_USING_LVGL_V820
+        default 0x99999    if PKG_USING_LVGL_LATEST_VERSION
+
     config PKG_LVGL_THREAD_PRIO
         int "priority of LVGL thread"
         default 20
@@ -25,16 +49,6 @@ if PKG_USING_LVGL
     config PKG_LVGL_USING_DEMOS
         bool "Enable built-in demos"
         default n
-
-    config PKG_LVGL_VER_NUM
-        hex
-        default 0x99999
-        default 0x08020    if RT_VER_NUM = 0x40100
-
-    config PKG_LVGL_VER
-       string
-       default "latest"    if PKG_LVGL_VER_NUM = 0x99999
-       default "v8.2.0"    if PKG_LVGL_VER_NUM = 0x08020
 
 endif
 


### PR DESCRIPTION
LVGL applications usually are developped on stable release, not the
latest. It makes sense to allow user having choice to select LVGL version.
If user has not adjusted their LVGL applications to use the new API
lv_user_gui_init(void), selecting stable v8.2.0 version can make their
old ones still working.

This reverts part of below commit:
https://github.com/RT-Thread/packages/commit/04a66bc5a3eed7bff10e17a905732305d97d704c

Signed-off-by: Ting Liu <ting.liu@nxp.com>