### PR TITLE
gui_guider_demo: fix pkg version

### DIFF
--- a/multimedia/LVGL/gui_guider_demo/Kconfig
+++ b/multimedia/LVGL/gui_guider_demo/Kconfig
@@ -12,6 +12,6 @@ if PKG_USING_GUI_GUIDER_DEMO
 
     config PKG_GUI_GUIDER_DEMO_VER
        string
-       default "latest"    if PKG_LVGL_VER_NUM = 0x99999 #LVGL latest version
+       default "latest"
 
 endif


### PR DESCRIPTION
Only one version is supported. Remove the check.
Fix below error:
> pkgs --update
Traceback (most recent call last):
  File "...\tools\ConEmu\ConEmu\..\..\..\tools\scripts\env.py", line 126, in <module>
    main()
  File "...\tools\ConEmu\ConEmu\..\..\..\tools\scripts\env.py", line 122, in main
    args.func(args)
  File "...\tools\scripts\cmds\cmd_package\__init__.py", line 44, in run_env_cmd
    package_update()
  File "...\tools\scripts\cmds\cmd_package\cmd_package_update.py", line 831, in package_update
    if not install_packages(sys_value, force_update):
  File "...\tools\scripts\cmds\cmd_package\cmd_package_update.py", line 781, in install_packages
    if install_package(env_root, pkgs_root, bsp_root, package, force_update):
  File "...\tools\scripts\cmds\cmd_package\cmd_package_update.py", line 254, in install_package
    url_from_json = package.get_url(package_info['ver'])
KeyError: 'ver'

Signed-off-by: Ting Liu <ting.liu@nxp.com>