### PR TITLE
[lvgl] using explicit version choice instead of hidden options

### DIFF
--- a/multimedia/LVGL/LVGL/Kconfig
+++ b/multimedia/LVGL/LVGL/Kconfig
@@ -29,19 +29,29 @@ if PKG_USING_LVGL
         bool "Enable built-in demos"
         default n
 
-    config PKG_LVGL_VER_NUM
-        hex
-        default 0x08030    if RT_VER_NUM = 0x40101
-        # NXP GUIGuider is designed for LVGL8.2.0 with RT-Thread latest version at this moment
-        # Thus, it needs to give a privilege to NXP GUIGuider to let it use LVGL8.2.0 even if RT-Thread vesion is higher than 4.1.0
-        default 0x08020    if (RT_VER_NUM = 0x40100) || ((RT_VER_NUM > 0x40100) && BSP_USING_NXP_GUIGUIDER)
-        default 0x99999
+    choice
+        prompt "Version"
+        default PKG_LVGL_USING_LATEST_VERSION
+        help
+            Select the LVGL package version
+            If RT-Thread vesion is higher than 4.1.0, we recommended to use LVGL v8.3.0 or latest.
+            If you use some special boards or tools, such as NXP GUIGuider. Maybe needs to choose LVGL v8.2.0.
+
+        config PKG_LVGL_USING_V08020
+            bool "v8.2.0"
+
+        config PKG_LVGL_USING_V08030
+            bool "v8.3.0"
+
+        config PKG_LVGL_USING_LATEST_VERSION
+            bool "latest"
+    endchoice
 
     config PKG_LVGL_VER
        string
-       default "latest"    if PKG_LVGL_VER_NUM = 0x99999
-       default "v8.3.0"    if PKG_LVGL_VER_NUM = 0x08030
-       default "v8.2.0"    if PKG_LVGL_VER_NUM = 0x08020
+       default "latest"    if PKG_LVGL_USING_LATEST_VERSION
+       default "v8.3.0"    if PKG_LVGL_USING_V08030
+       default "v8.2.0"    if PKG_LVGL_USING_V08020
 
 endif
 

--- a/multimedia/LVGL/lv_music_demo/Kconfig
+++ b/multimedia/LVGL/lv_music_demo/Kconfig
@@ -12,8 +12,8 @@ if PKG_USING_LV_MUSIC_DEMO
 
     config PKG_LV_MUSIC_DEMO_VER
        string
-       default "latest"    if PKG_LVGL_VER_NUM = 0x99999 #LVGL latest version
-       default "v0.2.0"    if PKG_LVGL_VER_NUM = 0x08020 #LVGL v8.2.0
-       default "v0.3.0"    if PKG_LVGL_VER_NUM = 0x08030 #LVGL v8.3.0
+       default "latest"    if PKG_LVGL_USING_LATEST_VERSION #LVGL latest version
+       default "v0.2.0"    if PKG_LVGL_USING_V08020         #LVGL v8.2.0
+       default "v0.3.0"    if PKG_LVGL_USING_V08030         #LVGL v8.3.0
 
 endif


### PR DESCRIPTION
BSP 包 nuvoton/nk-n9h30 添加 LVGL 软件包后，默认配置编译不通过，原因是部分源文件使用了 `LV_VERSION_CHECK` 宏检查版本是否为 v8.2.0，但是默认拉取的却是 latest 版本（已经到 v9.0 了）。

```c
#if LV_USE_GPU_N9H30_GE2D && LV_VERSION_CHECK(8, 2, 0)
```

这个 Bug 是在使用 NuMaker-HMI-N9H30 开发板的时候发现的，我不确定其他 BSP 包是否有类似的问题，但我认为显式地让用户决定 LVGL 的版本更合理。对于有特殊需求的 BSP 或者工具，例如 NXP GUIGuider，应该在其对应的 BSP、软件包、说明文档中进行适配或者给出提示，而不是在 Kconfig 中隐式处理。否则会给 LVGL 的开发者和相关软件包管理者带来不必要的麻烦。