### PR TITLE
add pico sdk

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -84,4 +84,5 @@ source "$PKGS_DIR/packages/peripherals/mb85rs16/Kconfig"
 source "$PKGS_DIR/packages/peripherals/cw2015/Kconfig"
 source "$PKGS_DIR/packages/peripherals/rfm300/Kconfig"
 source "$PKGS_DIR/packages/peripherals/io_input_filter/Kconfig"
+source "$PKGS_DIR/packages/peripherals/raspberrypi-pico-sdk/Kconfig"
 endmenu

--- a/peripherals/raspberrypi-pico-sdk/Kconfig
+++ b/peripherals/raspberrypi-pico-sdk/Kconfig
@@ -1,0 +1,28 @@
+
+# Kconfig file for package raspberrypi
+menuconfig PKG_USING_RASPBERRYPI_PICO_SDK
+    bool "Raspberry Pi Pico SDK"
+    default n
+
+if PKG_USING_RASPBERRYPI_PICO_SDK
+
+    config PKG_RASPBERRYPI_PICO_SDK_PATH
+        string
+        default "/packages/peripherals/raspberrypi-pico-sdk"
+
+    choice
+        prompt "Version"
+        default PKG_USING_RASPBERRYPI_PICO_SDK_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_RASPBERRYPI_PICO_SDK_LATEST_VERSION
+            bool "latest"
+    endchoice
+          
+    config PKG_RASPBERRYPI_PICO_SDK_VER
+       string
+       default "latest"    if PKG_USING_RASPBERRYPI_PICO_SDK_LATEST_VERSION
+
+endif
+

--- a/peripherals/raspberrypi-pico-sdk/package.json
+++ b/peripherals/raspberrypi-pico-sdk/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "raspberrypi-pico-sdk",
+  "description": "Raspberry Pi Pico SDK",
+  "description_zh": "Raspberry Pi Pico SDK",  
+  "enable": "PKG_USING_RASPBERRYPI_PICO_SDK", 
+  "keywords": [
+    "raspberrypi",
+    "pico",
+    "sdk"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "RT-Thread-packages",
+    "email": "package_team@rt-thread.com",
+    "github": "RT-Thread-packages"
+  },
+  "license": "BSD-3-Clause",
+  "repository": "https://github.com/RT-Thread-packages/raspberrypi-pico-sdk",
+  "icon": "unknown",
+  "homepage": "https://github.com/RT-Thread-packages/raspberrypi-pico-sdk#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/RT-Thread-packages/raspberrypi-pico-sdk.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
合并之后把主仓库pico里的sdk摘出来，占了一大堆的空间，还不是最新版本的