### PR TITLE
[mp3player] add optparse dependency

### DIFF
--- a/multimedia/mp3player/Kconfig
+++ b/multimedia/mp3player/Kconfig
@@ -4,6 +4,7 @@ menuconfig PKG_USING_MP3PLAYER
     bool "mp3player:a simple mp3 format music player"
     select RT_USING_AUDIO
     select PKG_USING_HELIX
+    select PKG_USING_OPTPARSE
     default n
 
 if PKG_USING_MP3PLAYER


### PR DESCRIPTION
修复 mp3player 软件包编译时出现的 fatal error: optparse.h: No such file or directory 错误，添加 optparse 软件包依赖。