### PR TITLE
[peripherals][micro_ros] Fix UDP bug and add standalone version

### DIFF
--- a/peripherals/micro_ros/Kconfig
+++ b/peripherals/micro_ros/Kconfig
@@ -41,12 +41,12 @@ if PKG_USING_MICRO_ROS
         config MICRO_ROS_USING_ARCH_CORTEX_M7_FPV5_SP_D16_SOFT
             bool "Cortex M7 (fpv5-sp-d16-soft)"
         config MICRO_ROS_USING_ARCH_CORTEX_M7_FPV5_SP_D16_HARD
-            bool "Cortex M7 (fpv5-sp-d16-)"
+            bool "Cortex M7 (fpv5-sp-d16-hard)"
     endchoice
 
     choice
         prompt "GCC Version"
-        default MICRO_ROS_GCC_5
+        default MICRO_ROS_USING_GCC_10
 
         config MICRO_ROS_USING_GCC_5
             bool "ARM GCC 5.x.x"
@@ -122,15 +122,15 @@ if PKG_USING_MICRO_ROS
 
     choice
         prompt "Version"
-        default PKG_USING_MICRO_ROS_HUMBLE_GCC_5
+        default PKG_USING_MICRO_ROS_HUMBLE_GCC_10
         help
             Select the package version
 
         if MICRO_ROS_USING_GCC_10
-            config PKG_USING_MICRO_ROS_HUMBLE
+            config PKG_USING_MICRO_ROS_HUMBLE_GCC_10
                 bool "humble-gcc-10"
 
-            config PKG_USING_MICRO_ROS_GALACTIC
+            config PKG_USING_MICRO_ROS_GALACTIC_GCC_10
                 bool "galactic-gcc-10"
         endif
 

--- a/peripherals/micro_ros/Kconfig
+++ b/peripherals/micro_ros/Kconfig
@@ -36,10 +36,12 @@ if PKG_USING_MICRO_ROS
             bool "Cortex M4 (fpv4-sp-d16-hard)"
         config MICRO_ROS_USING_ARCH_CORTEX_M7_FPV5_D16_SOFT
             bool "Cortex M7 (fpv5-d16-soft)"
-        config MICRO_ROS_USING_ARCH_CORTEX_M7_FPV5_SP_D16_SOFT
-            bool "Cortex M7 (fpv5-sp-d16-soft)"
         config MICRO_ROS_USING_ARCH_CORTEX_M7_FPV5_D16_HARD
             bool "Cortex M7 (fpv5-d16-hard)"
+        config MICRO_ROS_USING_ARCH_CORTEX_M7_FPV5_SP_D16_SOFT
+            bool "Cortex M7 (fpv5-sp-d16-soft)"
+        config MICRO_ROS_USING_ARCH_CORTEX_M7_FPV5_SP_D16_HARD
+            bool "Cortex M7 (fpv5-sp-d16-)"
     endchoice
 
     choice
@@ -57,26 +59,35 @@ if PKG_USING_MICRO_ROS
         string "serial device name"
         default "uart2"
 
-        config MICRO_ROS_USING_PUB_INT32
+    endif
+
+    config MICRO_ROS_USING_PUB_INT32
         bool "microros_pub_int32: microros publish int32 example"
         help
             microros publish int32 example
         default n
-    endif
-
-    if MICRO_ROS_USE_UDP
-        config MICRO_ROS_USING_PUB_INT32_UDP
-        bool "microros_pub_int32_udp: microros publish int32 udp example"
-        help
-            microros publish int32 udp example
-        default n
-    endif
 
     config MICRO_ROS_USING_SUB_INT32
         bool "microros_sub_int32: micro ros subscribe int32 example"
         help
             microros_sub_int32: micro ros subscribe int32 example
         default n
+
+    config MICRO_ROS_USING_PUB_SUB
+        bool "microros_pub_sub, micro ros pub sub example"
+        help
+            microros_pub_sub, micro ros pub sub example
+        default n
+
+    config MICRO_ROS_USING_PING_PONG
+        bool "microros_ping_pong, micro ros ping pong example"
+        help
+            microros_ping_pong, micro ros ping pong example
+        default n
+
+    if MICRO_ROS_USING_PING_PONG
+        comment "The Ping Pong example requires two pub and sub topics, please check the settings of rmw_microxrcedds in colcon.meta."
+    endif
 
     config MICRO_ROS_USING_SUB_TWIST
         bool "microros_sub_twist: micro ros subscribe to twist example"
@@ -111,15 +122,25 @@ if PKG_USING_MICRO_ROS
 
     choice
         prompt "Version"
-        default PKG_USING_MICRO_ROS_FOXY
+        default PKG_USING_MICRO_ROS_HUMBLE_GCC_5
         help
             Select the package version
 
-        config PKG_USING_MICRO_ROS_HUMBLE_V205
-            bool "humble-v2.0.5"
+        if MICRO_ROS_USING_GCC_10
+            config PKG_USING_MICRO_ROS_HUMBLE
+                bool "humble-gcc-10"
 
-        config PKG_USING_MICRO_ROS_GALACTIC_V205
-            bool "galactic-v2.0.5"
+            config PKG_USING_MICRO_ROS_GALACTIC
+                bool "galactic-gcc-10"
+        endif
+
+        if MICRO_ROS_USING_GCC_5
+            config PKG_USING_MICRO_ROS_HUMBLE_GCC_5
+                bool "humble-gcc-5"
+
+            config PKG_USING_MICRO_ROS_GALACTIC_GCC_5
+                bool "galactic-gcc-5"
+        endif
 
         config PKG_USING_MICRO_ROS_HUMBLE_STANDALONE
             bool "humble (standalone)"
@@ -138,8 +159,10 @@ if PKG_USING_MICRO_ROS
 
     config PKG_MICRO_ROS_VER
        string
-       default "humble-v2.0.5"              if PKG_USING_MICRO_ROS_HUMBLE_V205
-       default "galactic-v2.0.5"            if PKG_USING_MICRO_ROS_GALACTIC_V205
+       default "humble-gcc-10"              if PKG_USING_MICRO_ROS_HUMBLE_GCC_5
+       default "humble-gcc-5"               if PKG_USING_MICRO_ROS_HUMBLE_GCC_10
+       default "galactic-gcc-10"            if PKG_USING_MICRO_ROS_GALACTIC_GCC_10
+       default "galactic-gcc-5"             if PKG_USING_MICRO_ROS_GALACTIC_GCC_5
        default "humble-standalone"          if PKG_USING_MICRO_ROS_HUMBLE_STANDALONE
        default "galactic-standalone"        if PKG_USING_MICRO_ROS_GALACTIC_STANDALONE
        default "galactic-legacy"            if PKG_USING_MICRO_ROS_GALACTIC_LEGACY

--- a/peripherals/micro_ros/Kconfig
+++ b/peripherals/micro_ros/Kconfig
@@ -42,6 +42,16 @@ if PKG_USING_MICRO_ROS
             bool "Cortex M7 (fpv5-d16-hard)"
     endchoice
 
+    choice
+        prompt "GCC Version"
+        default MICRO_ROS_GCC_5
+
+        config MICRO_ROS_USING_GCC_5
+            bool "ARM GCC 5.x.x"
+        config MICRO_ROS_USING_GCC_10
+            bool "ARM GCC 10.x.x"
+    endchoice
+
     if MICRO_ROS_USE_SERIAL
         config MICRO_ROS_SERIAL_NAME
         string "serial device name"
@@ -105,17 +115,34 @@ if PKG_USING_MICRO_ROS
         help
             Select the package version
 
-        config PKG_USING_MICRO_ROS_FOXY
-            bool "foxy"
+        config PKG_USING_MICRO_ROS_HUMBLE_V205
+            bool "humble-v2.0.5"
 
-        config PKG_USING_MICRO_ROS_GALACTIC
-            bool "galactic"
+        config PKG_USING_MICRO_ROS_GALACTIC_V205
+            bool "galactic-v2.0.5"
+
+        config PKG_USING_MICRO_ROS_HUMBLE_STANDALONE
+            bool "humble (standalone)"
+
+        config PKG_USING_MICRO_ROS_GALACTIC_STANDALONE
+            bool "galactic (standalone)"
+
+        if MICRO_ROS_USING_GCC_5
+            config PKG_USING_MICRO_ROS_FOXY_LEGACY
+                bool "foxy (legacy)"
+
+            config PKG_USING_MICRO_ROS_GALACTIC_LEGACY
+                bool "galactic (legacy)"
+        endif
     endchoice
 
     config PKG_MICRO_ROS_VER
        string
-       default "foxy"           if PKG_USING_MICRO_ROS_FOXY
-       default "galactic"       if PKG_USING_MICRO_ROS_GALACTIC
+       default "humble-v2.0.5"              if PKG_USING_MICRO_ROS_HUMBLE_V205
+       default "galactic-v2.0.5"            if PKG_USING_MICRO_ROS_GALACTIC_V205
+       default "humble-standalone"          if PKG_USING_MICRO_ROS_HUMBLE_STANDALONE
+       default "galactic-standalone"        if PKG_USING_MICRO_ROS_GALACTIC_STANDALONE
+       default "galactic-legacy"            if PKG_USING_MICRO_ROS_GALACTIC_LEGACY
+       default "foxy-legacy"                if PKG_USING_MICRO_ROS_FOXY_LEGACY
 
 endif
-


### PR DESCRIPTION
**开源之夏 OSPP 2022 - MicroROS on RT-Thread**：

感谢 @navy-to-haijun 同学的贡献，micro_ros 在 RTT 上有了更好的支持：

- 修复了原来 UDP 通信 Segment Fault 的问题；
- 支持从源码编译 microros （只支持 linux 环境）；
- 增加了 ping pong 和 pub sub 例程；
- 增加了不同版本编译器的支持 gcc-5 和 gcc-10；

不过 upstream 到 micro_ros 官仓之前，我还要做一些测试，因为新版本 ROS2 默认的 DDS 从 FastDDS 变成了  CycloneDDS。