### PR TITLE
[peripheral][micro_ros] Add support for gcc-10 standalone for galactic and humble

### DIFF
--- a/peripherals/micro_ros/Kconfig
+++ b/peripherals/micro_ros/Kconfig
@@ -126,14 +126,6 @@ if PKG_USING_MICRO_ROS
         help
             Select the package version
 
-        if MICRO_ROS_USING_GCC_10
-            config PKG_USING_MICRO_ROS_HUMBLE_GCC_10
-                bool "humble-gcc-10"
-
-            config PKG_USING_MICRO_ROS_GALACTIC_GCC_10
-                bool "galactic-gcc-10"
-        endif
-
         if MICRO_ROS_USING_GCC_5
             config PKG_USING_MICRO_ROS_HUMBLE_GCC_5
                 bool "humble-gcc-5"
@@ -142,12 +134,6 @@ if PKG_USING_MICRO_ROS
                 bool "galactic-gcc-5"
         endif
 
-        config PKG_USING_MICRO_ROS_HUMBLE_STANDALONE
-            bool "humble (standalone)"
-
-        config PKG_USING_MICRO_ROS_GALACTIC_STANDALONE
-            bool "galactic (standalone)"
-
         if MICRO_ROS_USING_GCC_5
             config PKG_USING_MICRO_ROS_FOXY_LEGACY
                 bool "foxy (legacy)"
@@ -155,16 +141,33 @@ if PKG_USING_MICRO_ROS
             config PKG_USING_MICRO_ROS_GALACTIC_LEGACY
                 bool "galactic (legacy)"
         endif
+
+        if MICRO_ROS_USING_GCC_10
+            config PKG_USING_MICRO_ROS_HUMBLE_GCC_10
+                bool "humble-gcc-10"
+
+            config PKG_USING_MICRO_ROS_GALACTIC_GCC_10
+                bool "galactic-gcc-10"
+        endif
+
+        if MICRO_ROS_USING_GCC_10
+            config PKG_USING_MICRO_ROS_HUMBLE_GCC_10_STANDALONE
+                bool "humble-gcc-10 (standalone)"
+
+            config PKG_USING_MICRO_ROS_GALACTIC_GCC_10_STANDALONE
+                bool "galactic-gcc-10 (standalone)"
+        endif
+
     endchoice
 
     config PKG_MICRO_ROS_VER
        string
-       default "humble-gcc-10"              if PKG_USING_MICRO_ROS_HUMBLE_GCC_5
-       default "humble-gcc-5"               if PKG_USING_MICRO_ROS_HUMBLE_GCC_10
+       default "humble-gcc-10"              if PKG_USING_MICRO_ROS_HUMBLE_GCC_10
+       default "humble-gcc-5"               if PKG_USING_MICRO_ROS_HUMBLE_GCC_5
        default "galactic-gcc-10"            if PKG_USING_MICRO_ROS_GALACTIC_GCC_10
        default "galactic-gcc-5"             if PKG_USING_MICRO_ROS_GALACTIC_GCC_5
-       default "humble-standalone"          if PKG_USING_MICRO_ROS_HUMBLE_STANDALONE
-       default "galactic-standalone"        if PKG_USING_MICRO_ROS_GALACTIC_STANDALONE
+       default "humble-gcc-10-standalone"          if PKG_USING_MICRO_ROS_HUMBLE_GCC_10_STANDALONE
+       default "galactic-gcc-10-standalone"        if PKG_USING_MICRO_ROS_GALACTIC_GCC_10_STANDALONE
        default "galactic-legacy"            if PKG_USING_MICRO_ROS_GALACTIC_LEGACY
        default "foxy-legacy"                if PKG_USING_MICRO_ROS_FOXY_LEGACY
 

--- a/peripherals/micro_ros/package.json
+++ b/peripherals/micro_ros/package.json
@@ -23,16 +23,52 @@
   "doc": "unknown",
   "site": [
     {
-      "version": "foxy",
+      "version": "foxy-legacy",
       "URL": "https://github.com/wuhanstudio/micro_ros.git",
       "filename": "",
-      "VER_SHA": "foxy"
+      "VER_SHA": "foxy-legacy"
     },
     {
-      "version": "galactic",
+      "version": "galactic-legacy",
       "URL": "https://github.com/wuhanstudio/micro_ros.git",
       "filename": "",
-      "VER_SHA": "galactic"
+      "VER_SHA": "galactic-legacy"
+    },
+    {
+      "version": "galactic-gcc-5",
+      "URL": "https://github.com/wuhanstudio/micro_ros.git",
+      "filename": "",
+      "VER_SHA": "galactic-gcc-5"
+    },
+    {
+      "version": "galactic-gcc-10",
+      "URL": "https://github.com/wuhanstudio/micro_ros.git",
+      "filename": "",
+      "VER_SHA": "galactic-gcc-10"
+    },
+    {
+      "version": "galactic-gcc-10-standalone",
+      "URL": "https://github.com/wuhanstudio/micro_ros.git",
+      "filename": "",
+      "VER_SHA": "galactic-standalone-gcc-10"
+    },
+    {
+      "version": "humble-gcc-5",
+      "URL": "https://github.com/wuhanstudio/micro_ros.git",
+      "filename": "",
+      "VER_SHA": "humble-gcc-5"
+    },
+    {
+      "version": "humble-gcc-10",
+      "URL": "https://github.com/wuhanstudio/micro_ros.git",
+      "filename": "",
+      "VER_SHA": "humble-gcc-10"
+    },
+    {
+      "version": "humble-gcc-10-standalone",
+      "URL": "https://github.com/wuhanstudio/micro_ros.git",
+      "filename": "",
+      "VER_SHA": "humble-standalone-gcc-10"
     }
   ]
 }


### PR DESCRIPTION
在 KConfig 里增加限制：micro_ros 从源码编译只支持 gcc-10。

- [修复] galactic-standalone 和 humble-standalone 只支持 gcc-10
