### PR TITLE
[kconfig] choice语法块中不可再包含if语法块

### DIFF
--- a/iot/netutils/Kconfig
+++ b/iot/netutils/Kconfig
@@ -124,8 +124,6 @@ if PKG_USING_NETUTILS
         prompt "Version"
         help
             Select the netutils version
-        default PKG_USING_NETUTILS_LATEST_VERSION if RT_VER_NUM = 0x40100
-        default PKG_USING_NETUTILS_V132
 
         config PKG_USING_NETUTILS_LATEST_VERSION
             bool "latest"

--- a/iot/pahomqtt/Kconfig
+++ b/iot/pahomqtt/Kconfig
@@ -61,19 +61,17 @@ if PKG_USING_PAHOMQTT
 
         ### Notice, the posix/libc had changed the structure of folder since RT-Thread V4.1.0.
         ### if the pahomqtt will release new tag, should add it here.
-        if RT_VER_NUM >= 0x40100
-            config PKG_USING_PAHOMQTT_LATEST
-                bool "latest"
-        endif
+        config PKG_USING_PAHOMQTT_LATEST
+            bool "latest"
+            depends on RT_VER_NUM >= 0x40100
 
-        if RT_VER_NUM < 0x40100
-            config PKG_USING_PAHOMQTT_V110
-                bool "v1.1.0"
+        config PKG_USING_PAHOMQTT_V110
+            bool "v1.1.0"
+            depends on RT_VER_NUM < 0x40100
 
-            config PKG_USING_PAHOMQTT_V100
-                bool "v1.0.0"
-        endif
-
+        config PKG_USING_PAHOMQTT_V100
+            bool "v1.0.0"
+            depends on RT_VER_NUM < 0x40100
     endchoice
 
     config PKG_PAHOMQTT_VER

--- a/peripherals/kendryte-sdk/K210-SDK/kendryte-sdk/Kconfig
+++ b/peripherals/kendryte-sdk/K210-SDK/kendryte-sdk/Kconfig
@@ -15,28 +15,31 @@ if PKG_USING_KENDRYTE_SDK
         help
             Select the package version
 
-        if RT_VER_NUM < 0x40004
-            config PKG_USING_KENDRYTE_SDK_V052
-                bool "v0.5.2"
-
-            config PKG_USING_KENDRYTE_SDK_V053
-                bool "v0.5.3"
-
-            config PKG_USING_KENDRYTE_SDK_V054
-                bool "v0.5.4"
-
-            config PKG_USING_KENDRYTE_SDK_V055
-                bool "v0.5.5"
-
-            config PKG_USING_KENDRYTE_SDK_V056
-                bool "v0.5.6"
-        endif
+        config PKG_USING_KENDRYTE_SDK_LATEST_VERSION
+            bool "latest"
 
         config PKG_USING_KENDRYTE_SDK_V057
             bool "v0.5.7"
 
-        config PKG_USING_KENDRYTE_SDK_LATEST_VERSION
-            bool "latest"
+        config PKG_USING_KENDRYTE_SDK_V056
+            bool "v0.5.6"
+            depends on RT_VER_NUM < 0x40004
+
+        config PKG_USING_KENDRYTE_SDK_V055
+            bool "v0.5.5"
+            depends on RT_VER_NUM < 0x40004
+
+        config PKG_USING_KENDRYTE_SDK_V054
+            bool "v0.5.4"
+            depends on RT_VER_NUM < 0x40004
+
+        config PKG_USING_KENDRYTE_SDK_V053
+            bool "v0.5.3"
+            depends on RT_VER_NUM < 0x40004
+
+        config PKG_USING_KENDRYTE_SDK_V052
+            bool "v0.5.2"
+            depends on RT_VER_NUM < 0x40004
     endchoice
 
     config PKG_KENDRYTE_SDK_VER

--- a/peripherals/rc522/Kconfig
+++ b/peripherals/rc522/Kconfig
@@ -39,9 +39,6 @@ if PKG_USING_RC522
         help
             Select the package version
 
-        config PKG_USING_RC522_LATEST_VERSION
-            bool "latest"
-
         config PKG_USING_RC522_V10410
             bool "v1.4.10"
 
@@ -49,6 +46,8 @@ if PKG_USING_RC522
             bool "v1.4.5"
             depends on RT_VER_NUM < 0x40101
 
+        config PKG_USING_RC522_LATEST_VERSION
+            bool "latest"
     endchoice
 
     config PKG_RC522_VER

--- a/peripherals/rc522/Kconfig
+++ b/peripherals/rc522/Kconfig
@@ -39,16 +39,16 @@ if PKG_USING_RC522
         help
             Select the package version
 
+        config PKG_USING_RC522_LATEST_VERSION
+            bool "latest"
+
         config PKG_USING_RC522_V10410
             bool "v1.4.10"
 
-        if RT_VER_NUM < 0x40101
-            config PKG_USING_RC522_V10405
-                bool "v1.4.5"
-        endif
+        config PKG_USING_RC522_V10405
+            bool "v1.4.5"
+            depends on RT_VER_NUM < 0x40101
 
-        config PKG_USING_RC522_LATEST_VERSION
-            bool "latest"
     endchoice
 
     config PKG_RC522_VER

--- a/peripherals/sensors/aht10/Kconfig
+++ b/peripherals/sensors/aht10/Kconfig
@@ -41,21 +41,21 @@ if PKG_USING_AHT10
         help
             Select the package version
 
-        if RT_VER_NUM >= 0x50000
-            config PKG_USING_AHT10_LATEST_VERSION
-                bool "latest"
-        endif
+        config PKG_USING_AHT10_LATEST_VERSION
+            bool "latest"
+            depends on RT_VER_NUM >= 0x50000
 
-        if RT_VER_NUM < 0x50000 
-            config PKG_USING_AHT10_V210
-                bool "v2.1.0"
+        config PKG_USING_AHT10_V210
+            bool "v2.1.0"
+            depends on RT_VER_NUM < 0x50000 
 
-            config PKG_USING_AHT10_V200
-                bool "v2.0.0"
+        config PKG_USING_AHT10_V200
+            bool "v2.0.0"
+            depends on RT_VER_NUM < 0x50000 
 
-            config PKG_USING_AHT10_V100
-                bool "v1.0.0"
-        endif
+        config PKG_USING_AHT10_V100
+            bool "v1.0.0"
+            depends on RT_VER_NUM < 0x50000
 
     endchoice
 

--- a/peripherals/sensors/ap3216c/Kconfig
+++ b/peripherals/sensors/ap3216c/Kconfig
@@ -36,17 +36,15 @@ if PKG_USING_AP3216C
         help
             Select the package version
 
-        if RT_VER_NUM >= 0x50000
-            config PKG_USING_AP3216C_LATEST_VERSION
-                bool "latest"
-        endif
+        config PKG_USING_AP3216C_LATEST_VERSION
+            bool "latest"
+            depends on RT_VER_NUM >= 0x50000
 
         config PKG_USING_AP3216C_V200
             bool "v2.0.0"
 
         config PKG_USING_AP3216C_V100
             bool "v1.0.0"
-
     endchoice
 
     config PKG_AP3216C_VER

--- a/peripherals/sensors/mpu6xxx/Kconfig
+++ b/peripherals/sensors/mpu6xxx/Kconfig
@@ -15,22 +15,21 @@ if PKG_USING_MPU6XXX
         help
             Select the package version
 
-        if RT_VER_NUM >= 0x50000
-            config PKG_USING_MPU6XXX_LATEST_VERSION
-                bool "latest"
-        endif
+        config PKG_USING_MPU6XXX_LATEST_VERSION
+            bool "latest"
+            depends on RT_VER_NUM >= 0x50000
 
-        if RT_VER_NUM < 0x50000
-            config PKG_USING_MPU6XXX_V111
-                bool "v1.1.1"
+        config PKG_USING_MPU6XXX_V111
+            bool "v1.1.1"
+            depends on RT_VER_NUM < 0x50000
 
-            config PKG_USING_MPU6XXX_V110
-                bool "v1.1.0"
+        config PKG_USING_MPU6XXX_V110
+            bool "v1.1.0"
+            depends on RT_VER_NUM < 0x50000
 
-            config PKG_USING_MPU6XXX_V100
-                bool "v1.0.0"
-        endif
-
+        config PKG_USING_MPU6XXX_V100
+            bool "v1.0.0"
+            depends on RT_VER_NUM < 0x50000
     endchoice
 
     config PKG_MPU6XXX_VER


### PR DESCRIPTION
针对Kconfig文件下，需要注意choice选择块内，不可再包含if块，否则在Kconfig-C版本前端中无法正确识别（python前端可以正确识别 https://github.com/RT-Thread/packages/issues/1564