### PR TITLE
[0 error pkg] 软件包wm_libraries修复

### DIFF
--- a/peripherals/wm_libraries/Kconfig
+++ b/peripherals/wm_libraries/Kconfig
@@ -2,6 +2,7 @@
 # Kconfig file for package wm_libraries
 menuconfig PKG_USING_WM_LIBRARIES
     bool "wm_libraries: a library package for WinnerMicro devices."
+    depends on ARCH_ARM_CORTEX_M3
     default n
 
 if PKG_USING_WM_LIBRARIES

--- a/peripherals/wm_libraries/package.json
+++ b/peripherals/wm_libraries/package.json
@@ -30,7 +30,7 @@
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://github.com/WinnerMicro/rtpkg-wm_libraries/archive/refs/tags/v1.0.0.zip",
+      "URL": "https://github.com/WinnerMicro/rtpkg-wm_libraries.git",
       "filename": "wm_libraries-1.0.0.zip",
       "VER_SHA": "13f2cc4a4761526cadab9fa31296f1d24fabef8a"
     },

--- a/peripherals/wm_libraries/package.json
+++ b/peripherals/wm_libraries/package.json
@@ -30,7 +30,7 @@
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://github.com/WinnerMicro/rtpkg-wm_libraries.git",
+      "URL": "https://github.com/WinnerMicro/rtpkg-wm_libraries/archive/refs/tags/v1.0.0.zip",
       "filename": "wm_libraries-1.0.0.zip",
       "VER_SHA": "13f2cc4a4761526cadab9fa31296f1d24fabef8a"
     },


### PR DESCRIPTION
wm_libraries目前似乎仅支持m3核，使用RTT软件包测试工具时无法通过，此处添加Kconfig依赖项，对非m3核bsp不做该软件包的使用