### PR TITLE
[0 error pkg] modify Kconfig file

### DIFF
--- a/peripherals/wm_libraries/Kconfig
+++ b/peripherals/wm_libraries/Kconfig
@@ -4,8 +4,7 @@ menuconfig PKG_USING_WM_LIBRARIES
     bool "wm_libraries: a library package for WinnerMicro devices."
     default n
 
-if PKG_USING_WM_LIBRARIES
-    depends on ARCH_ARM_CORTEX_M3
+if PKG_USING_WM_LIBRARIES && ARCH_ARM_CORTEX_M3
 
     config PKG_WM_LIBRARIES_PATH
         string

--- a/peripherals/wm_libraries/Kconfig
+++ b/peripherals/wm_libraries/Kconfig
@@ -4,7 +4,7 @@ menuconfig PKG_USING_WM_LIBRARIES
     bool "wm_libraries: a library package for WinnerMicro devices."
     default n
 
-if PKG_USING_WM_LIBRARIES
+if PKG_USING_WM_LIBRARIES && ARCH_ARM_CORTEX_M3
 
     config PKG_WM_LIBRARIES_PATH
         string

--- a/peripherals/wm_libraries/Kconfig
+++ b/peripherals/wm_libraries/Kconfig
@@ -4,7 +4,7 @@ menuconfig PKG_USING_WM_LIBRARIES
     bool "wm_libraries: a library package for WinnerMicro devices."
     default n
 
-if PKG_USING_WM_LIBRARIES && ARCH_ARM_CORTEX_M3
+if PKG_USING_WM_LIBRARIES
 
     config PKG_USING_WM_LIBRARIES
         depends on ARCH_ARM_CORTEX_M3

--- a/peripherals/wm_libraries/Kconfig
+++ b/peripherals/wm_libraries/Kconfig
@@ -6,6 +6,10 @@ menuconfig PKG_USING_WM_LIBRARIES
 
 if PKG_USING_WM_LIBRARIES && ARCH_ARM_CORTEX_M3
 
+    config PKG_USING_WM_LIBRARIES
+        depends on ARCH_ARM_CORTEX_M3
+        default n
+
     config PKG_WM_LIBRARIES_PATH
         string
         default "/packages/peripherals/wm_libraries"

--- a/peripherals/wm_libraries/Kconfig
+++ b/peripherals/wm_libraries/Kconfig
@@ -4,7 +4,8 @@ menuconfig PKG_USING_WM_LIBRARIES
     bool "wm_libraries: a library package for WinnerMicro devices."
     default n
 
-if PKG_USING_WM_LIBRARIES && ARCH_ARM_CORTEX_M3
+if PKG_USING_WM_LIBRARIES
+    depends on ARCH_ARM_CORTEX_M3
 
     config PKG_WM_LIBRARIES_PATH
         string


### PR DESCRIPTION
wm_libraries目前似乎仅支持m3核，使用RTT软件包测试工具时无法通过，此处添加Kconfig依赖项，对非m3核bsp不做该软件包的使用