### PR TITLE
fix the quicklz failed to compile.

### DIFF
--- a/misc/quicklz/Kconfig
+++ b/misc/quicklz/Kconfig
@@ -14,6 +14,7 @@ if PKG_USING_QUICKLZ
         default n
         select RT_USING_DFS      if RT_VER_NUM < 0x40100
         select RT_USING_POSIX_FS if RT_VER_NUM >= 0x40100
+        select RT_USING_LEGACY
 
     config QLZ_COMPRESSION_LEVEL
         help


### PR DESCRIPTION
修正quicklz的sample编译报找不到dfs_posix.h的问题