### PR TITLE
micro_ros Kconfig中Version部分的bug修复

### DIFF
--- a/arduino/devicecontrol/Adafruit-DS3502/Kconfig
+++ b/arduino/devicecontrol/Adafruit-DS3502/Kconfig
@@ -1,7 +1,7 @@
 
 # Kconfig file for package Adafruit-DS3502
 menuconfig PKG_USING_ARDUINO_ADAFRUIT_DS3502
-    bool " Adafruit DS3502: Digital Potentiometer"
+    bool   "Adafruit DS3502: Digital Potentiometer"
     select PKG_USING_RTDUINO
     select RTDUINO_USING_WIRE
     select PKG_USING_ARDUINO_ADAFRUIT_BUSIO

--- a/peripherals/micro_ros/Kconfig
+++ b/peripherals/micro_ros/Kconfig
@@ -122,41 +122,42 @@ if PKG_USING_MICRO_ROS
 
     choice
         prompt "Version"
-        default PKG_USING_MICRO_ROS_HUMBLE_GCC_10
+        default PKG_USING_MICRO_ROS_HUMBLE_GCC_10   if MICRO_ROS_USING_GCC_10
+        default PKG_USING_MICRO_ROS_HUMBLE_GCC_5    if MICRO_ROS_USING_GCC_5
         help
             Select the package version
 
-        if MICRO_ROS_USING_GCC_5
-            config PKG_USING_MICRO_ROS_HUMBLE_GCC_5
-                bool "humble-gcc-5"
+        config PKG_USING_MICRO_ROS_HUMBLE_GCC_5
+            bool "humble-gcc-5"
+            depends on MICRO_ROS_USING_GCC_5
 
-            config PKG_USING_MICRO_ROS_GALACTIC_GCC_5
-                bool "galactic-gcc-5"
-        endif
+        config PKG_USING_MICRO_ROS_GALACTIC_GCC_5
+            bool "galactic-gcc-5"
+            depends on MICRO_ROS_USING_GCC_5
 
-        if MICRO_ROS_USING_GCC_5
-            config PKG_USING_MICRO_ROS_FOXY_LEGACY
-                bool "foxy (legacy)"
+        config PKG_USING_MICRO_ROS_FOXY_LEGACY
+            bool "foxy (legacy)"
+            depends on MICRO_ROS_USING_GCC_5
 
-            config PKG_USING_MICRO_ROS_GALACTIC_LEGACY
-                bool "galactic (legacy)"
-        endif
+        config PKG_USING_MICRO_ROS_GALACTIC_LEGACY
+            bool "galactic (legacy)"
+            depends on MICRO_ROS_USING_GCC_5
 
-        if MICRO_ROS_USING_GCC_10
-            config PKG_USING_MICRO_ROS_HUMBLE_GCC_10
-                bool "humble-gcc-10"
+        config PKG_USING_MICRO_ROS_HUMBLE_GCC_10
+            bool "humble-gcc-10"
+            depends on MICRO_ROS_USING_GCC_10
 
-            config PKG_USING_MICRO_ROS_GALACTIC_GCC_10
-                bool "galactic-gcc-10"
-        endif
+        config PKG_USING_MICRO_ROS_GALACTIC_GCC_10
+            bool "galactic-gcc-10"
+            depends on MICRO_ROS_USING_GCC_10
 
-        if MICRO_ROS_USING_GCC_10
-            config PKG_USING_MICRO_ROS_HUMBLE_GCC_10_STANDALONE
-                bool "humble-gcc-10 (standalone)"
+        config PKG_USING_MICRO_ROS_HUMBLE_GCC_10_STANDALONE
+            bool "humble-gcc-10 (standalone)"
+            depends on MICRO_ROS_USING_GCC_10
 
-            config PKG_USING_MICRO_ROS_GALACTIC_GCC_10_STANDALONE
-                bool "galactic-gcc-10 (standalone)"
-        endif
+        config PKG_USING_MICRO_ROS_GALACTIC_GCC_10_STANDALONE
+            bool "galactic-gcc-10 (standalone)"
+            depends on MICRO_ROS_USING_GCC_10
 
     endchoice
 

--- a/security/mbedtls/Kconfig
+++ b/security/mbedtls/Kconfig
@@ -7,7 +7,7 @@ menuconfig PKG_USING_MBEDTLS
     select SAL_USING_POSIX          if RT_VER_NUM < 0x40100
     select RT_USING_POSIX_FS        if RT_VER_NUM >= 0x40100
     select RT_USING_POSIX_SOCKET    if RT_VER_NUM >= 0x40100
-    imply SAL_USING_TLS            if RT_USING_SAL
+    imply SAL_USING_TLS             if RT_USING_SAL
 
 if PKG_USING_MBEDTLS
 


### PR DESCRIPTION
修复了micro_ros因Kconfig语法问题导致无法选择package version的bug。
其余是scons --menuconfig时看到的多出空格的小问题。