### PR TITLE
[pkgs][ali-iotkit] Change the default software package version in the kconfig file to latest

### DIFF
--- a/iot/iot_cloud/ali-iotkit/Kconfig
+++ b/iot/iot_cloud/ali-iotkit/Kconfig
@@ -82,7 +82,7 @@ if PKG_USING_ALI_IOTKIT
 
     choice
         prompt "Version"
-        default PKG_USING_ALI_IOTKIT_V30001
+        default PKG_USING_ALI_IOTKIT_LATEST_VERSION
         help
             Select the ali-iotkit version
 


### PR DESCRIPTION
软件包v3.0.1物模型示例工程有独立一套sJSON库，与软件包依赖绑定的cJSON库会产生冲突，而latest版本中则已完成修复，因此修改默认版本为latest