### PR TITLE
release TinyUSB 0.13.1

### DIFF
--- a/system/TinyUSB/Kconfig
+++ b/system/TinyUSB/Kconfig
@@ -248,6 +248,9 @@ if PKG_USING_TINYUSB
         config PKG_USING_TINYUSB_V01400
             bool "v0.14.0"
 
+        config PKG_USING_TINYUSB_V01301
+            bool "v0.13.1"
+
         config PKG_USING_TINYUSB_V01300
             bool "v0.13.0"
 
@@ -260,5 +263,6 @@ if PKG_USING_TINYUSB
        default "latest"  if PKG_USING_TINYUSB_LATEST_VERSION
        default "v0.14.0" if PKG_USING_TINYUSB_V01400
        default "v0.13.0" if PKG_USING_TINYUSB_V01300
+       default "v0.13.1" if PKG_USING_TINYUSB_V01301
 
 endif

--- a/system/TinyUSB/package.json
+++ b/system/TinyUSB/package.json
@@ -30,6 +30,11 @@
       "filename": "tinyusb-0.13.0.zip"
     },
     {
+      "version": "v0.13.1",
+      "URL": "https://github.com/RT-Thread-packages/tinyusb/archive/0.13.1.zip",
+      "filename": "tinyusb-0.13.1.zip"
+    },
+    {
       "version": "v0.14.0",
       "URL": "https://github.com/RT-Thread-packages/tinyusb/archive/0.14.0.zip",
       "filename": "tinyusb-0.14.0.zip"


### PR DESCRIPTION
发布修复版本。

[Release Note](https://github.com/RT-Thread-packages/tinyusb/releases/tag/0.13.1)