### PR TITLE
[Actions]Add test all packages.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -43,6 +43,3 @@ jobs:
             cd ${RTT_ROOT}/bsp/qemu-vexpress-a9 && sudo -E ../../tools/kconfig-frontends/kconfig-mconf Kconfig -n
             cp ${RTT_ROOT}/tools/kconfiglib.py ./ && python -c 'import kconfiglib; kconfiglib.standard_kconfig()'
             cd ${PKGS_ROOT}/packages && python ci.py
-
-  pkgs-test:
-    uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main

--- a/.github/workflows/pkgs-test.yml
+++ b/.github/workflows/pkgs-test.yml
@@ -1,0 +1,104 @@
+name: Packages Test
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+    push:
+        branches:
+          - master
+    pull_request:
+        branches:
+            - master
+    workflow_dispatch:
+    # Runs at 00:00 UTC on the 1, 16 and 31th of every month、
+    schedule:
+        - cron:  '0 0 */15 * *'
+
+
+# Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+permissions:
+    pages: write      # to deploy to Pages
+    id-token: write   # to verify the deployment originates from an appropriate source
+
+concurrency:
+    group: pkgs-test
+    cancel-in-progress: false # wait for finish.
+
+jobs:
+    change:
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push'}}
+        uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
+        with:
+            package-append-res: true
+            deploy-pages: true
+
+    master-stm32h750-artpi-test:
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
+        uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
+        with:
+            bsps: stm32/stm32h750-artpi:sourcery-arm
+            rt-thread-versions: branch:master
+            package-append-res: true
+            package-test-all: true
+            deploy-pages: true
+            check-errors: false
+
+    master-k210-test:
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
+        needs: master-stm32h750-artpi-test
+        uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
+        with:
+            bsps: k210:sourcery-riscv-none-embed
+            rt-thread-versions: branch:master
+            package-append-res: true
+            package-test-all: true
+            deploy-pages: true
+            check-errors: false
+
+    master-qemu-vexpress-a9-test:
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
+        needs: master-k210-test
+        uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
+        with:
+            bsps: qemu-vexpress-a9:sourcery-arm
+            rt-thread-versions: branch:master
+            package-append-res: true
+            package-test-all: true
+            deploy-pages: true
+            check-errors: false
+
+    v4_1_1-stm32h750-artpi-test:
+        needs: master-qemu-vexpress-a9-test
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
+        uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
+        with:
+            bsps: stm32/stm32h750-artpi:sourcery-arm
+            rt-thread-versions: tag:v4.1.1
+            package-append-res: true
+            package-test-all: true
+            deploy-pages: true
+            check-errors: false
+
+    v4_1_1-k210-test:
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
+        needs: v4_1_1-stm32h750-artpi-test
+        uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
+        with:
+            bsps: k210:sourcery-riscv-none-embed
+            rt-thread-versions: tag:v4.1.1
+            package-append-res: true
+            package-test-all: true
+            deploy-pages: true
+            check-errors: false
+
+    v4_1_1-qemu-vexpress-a9-test:
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'}}
+        needs: v4_1_1-k210-test
+        uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
+        with:
+            bsps: qemu-vexpress-a9:sourcery-arm
+            rt-thread-versions: tag:v4.1.1
+            package-append-res: true
+            package-test-all: true
+            deploy-pages: true
+            check-errors: false


### PR DESCRIPTION
目前的软件包测试只有当软件包发生更改时（push或pull_request）对改动的部分进行测试，
在此基础上**添加了定时执行的针对全部软件包的测试**。

1. 每个job单独测试一个rt-thread版本一个bsp，总计有6个job。
> rt-thread：
> 1. master
> 2. v4.1.1

> bsp：
> 1. qemu-vexpress-a9
> 2. stm32h750-artpi
> 4. k210

2. 测试结束后将测试报告发布到githubpage页面上面。这里需要开启Pages并且选择来源，我自己的仓库是这样的

<img width="1087" alt="image" src="https://github.com/RT-Thread/packages/assets/34151213/2f431cb7-7c18-4ca2-aa13-7cd603b8adde">

> 预计的页面地址在 https://rt-thread.github.io/packages/ ，我这里有个例子https://vacabun.github.io/packages/

3. 每次生成的测试结果报告会和旧的测试结果合并（通过从githubpage获取旧的）。
> 对于冲突问题，通过github actions的concurrency限制了workflow的并发数，当触发新的会等待旧的运行结束。

4. 此外发布了一个包含测试结果的json，名字叫`pkgs_res.json`，如果有其他地方想要获取软件包测试的结果可以从这里读取。
> 这里有一个例子 https://vacabun.github.io/packages/pkgs_res.json

5. 同时针对全部软件包的测试也增加了手动触发方式（workflow_dispatch）。

最后**总结说明**一下，对于软件包测试分为两种情况：

1. 软件包发生更改时（push、pull_request）对改动的部分进行测试。
2. 定时或手动（workflow_dispatch、schedule）执行的针对全部软件包的测试。
