### PR TITLE
[Actions] fix pkgs_test deploy permission.

### DIFF
--- a/.github/workflows/pkgs-test.yml
+++ b/.github/workflows/pkgs-test.yml
@@ -25,8 +25,15 @@ concurrency:
     cancel-in-progress: false # wait for finish.
 
 jobs:
-    change:
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push'}}
+    change_pull_request:
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
+        with:
+            package-append-res: true
+            deploy-pages: false
+
+    change_push:
+        if: ${{ github.event_name == 'push' }}
         uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
         with:
             package-append-res: true


### PR DESCRIPTION
问题：https://github.com/RT-Thread/packages/pull/1647
没有仓库权限的开发者提交pr检查的时候无法发布github pages。

解决：
pr最后合并的时候Actions的触发来源是push。
所以将pr和push分开，仅在push的时候才发布github pages。
这样仅在合并的时候才更新github pages。