### PR TITLE
[CI] Add VER_SHA and URL check.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -43,3 +43,5 @@ jobs:
             cd ${RTT_ROOT}/bsp/qemu-vexpress-a9 && sudo -E ../../tools/kconfig-frontends/kconfig-mconf Kconfig -n
             cp ${RTT_ROOT}/tools/kconfiglib.py ./ && python -c 'import kconfiglib; kconfiglib.standard_kconfig()'
             cd ${PKGS_ROOT}/packages && python ci.py
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ai/ncnn/package.json
+++ b/ai/ncnn/package.json
@@ -26,7 +26,7 @@
       "version": "latest",
       "URL": "https://github.com/yc66542260/ncnn-rtthread.git",
       "filename": "",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/arduino/sensors/Adafruit-VL53L1X/package.json
+++ b/arduino/sensors/Adafruit-VL53L1X/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/adafruit/Adafruit_VL53L1X.git",
       "filename": "",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/iot/btstack/package.json
+++ b/iot/btstack/package.json
@@ -36,7 +36,7 @@
       "version": "latest",
       "URL": "https://github.com/supperthomas/RTT_PACKAGE_BTSTACK.git",
       "filename": "Null for git package",
-      "VER_SHA": "fill in latest version branch name, such as master"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/iot/llsync_sdk_adapter/package.json
+++ b/iot/llsync_sdk_adapter/package.json
@@ -29,7 +29,7 @@
       "version": "latest",
       "URL": "https://github.com/supperthomas/LLSync_sdk_adapter.git",
       "filename": "LLSync_sdk_adapter",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/iot/lora_pkt_fwd/package.json
+++ b/iot/lora_pkt_fwd/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/forest-rain/lora-pkt-fwd.git",
       "filename": "Null for git package",
-      "VER_SHA": "fill in latest version branch name, such as master"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/iot/lora_pkt_sniffer/package.json
+++ b/iot/lora_pkt_sniffer/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/forest-rain/lora-pkt-sniffer.git",
       "filename": "lora-packet-sniffer for git package",
-      "VER_SHA": "fill in latest version branch name, such as master"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/iot/zFTP/package.json
+++ b/iot/zFTP/package.json
@@ -20,9 +20,8 @@
   "site": [
     {
       "version": "V1.0",
-      "URL": "https://github.com/longtengmcu/zFTP.git",
-      "filename": "zFTP-1.0.zip",
-      "VER_SHA": "fill in the git version SHA value"
+      "URL": "https://github.com/longtengmcu/zFTP/archive/V1.0.zip",
+      "filename": "zFTP-1.0.zip"
     },
     {
       "version": "latest",

--- a/language/LuatOS/package.json
+++ b/language/LuatOS/package.json
@@ -23,7 +23,7 @@
       "version": "latest",
       "URL": "https://github.com/openLuat/luatos-soc-rtt.git",
       "filename": "Null for git package",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/misc/slcan2rtt/package.json
+++ b/misc/slcan2rtt/package.json
@@ -32,7 +32,7 @@
       "version": "latest",
       "URL": "https://github.com/cazure/slcan2rtt.git",
       "filename": "slcan2rtt-master.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/multimedia/NUemWin/package.json
+++ b/multimedia/NUemWin/package.json
@@ -19,7 +19,7 @@
       "version": "latest",
       "URL": "https://github.com/wosayttn/NUemWin.git",
       "filename": "NUemWin.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/multimedia/TinyJPEG/package.json
+++ b/multimedia/TinyJPEG/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/StackRyan/TinyJPEG.git",
       "filename": "Null for git package",
-      "VER_SHA": "fill in latest version branch name, such as master"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/multimedia/touchgfx2rtt/package.json
+++ b/multimedia/touchgfx2rtt/package.json
@@ -19,7 +19,7 @@
       "version": "latest",
       "URL": "https://github.com/Aladdin-Wang/touchgfx2rtt.git",
       "filename": "touchgfx2rtt.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/MotionDriver2RTT/package.json
+++ b/peripherals/MotionDriver2RTT/package.json
@@ -22,9 +22,8 @@
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://github.com/greedyhao/MotionDriver2RTT.git",
-      "filename": "MotionDriver2RTT-1.0.0.zip",
-      "VER_SHA": "NULL"
+      "URL": "https://github.com/greedyhao/MotionDriver2RTT/archive/v1.0.0.zip",
+      "filename": "MotionDriver2RTT-1.0.0.zip"
     },
     {
       "version": "latest",

--- a/peripherals/ili9341/package.json
+++ b/peripherals/ili9341/package.json
@@ -26,7 +26,7 @@
             "version": "latest",
             "URL": "https://github.com/Rbb666/ILI9341.git",
             "filename": "Null for git package",
-            "VER_SHA": "master"
+            "VER_SHA": "main"
         }
     ]
 }

--- a/peripherals/kendryte-sdk/K210-SDK/kendryte-sdk/package.json
+++ b/peripherals/kendryte-sdk/K210-SDK/kendryte-sdk/package.json
@@ -28,33 +28,28 @@
     },
     {
       "version": "v0.5.3",
-      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk.git",
-      "filename": "kendryte-sdk-0.5.3.zip",
-      "VER_SHA": "v0.5.3"
+      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk/archive/v0.5.3.zip",
+      "filename": "kendryte-sdk-0.5.3.zip"
     },
     {
       "version": "v0.5.4",
-      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk.git",
-      "filename": "kendryte-sdk-0.5.4.zip",
-      "VER_SHA": "v0.5.4"
+      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk/archive/v0.5.4.zip",
+      "filename": "kendryte-sdk-0.5.4.zip"
     },
     {
       "version": "v0.5.5",
-      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk.git",
-      "filename": "kendryte-sdk-0.5.5.zip",
-      "VER_SHA": "v0.5.5"
+      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk/archive/v0.5.5.zip",
+      "filename": "kendryte-sdk-0.5.5.zip"
     },
     {
       "version": "v0.5.6",
-      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk.git",
-      "filename": "kendryte-sdk-0.5.6.zip",
-      "VER_SHA": "v0.5.6"
+      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk/archive/v0.5.6.zip",
+      "filename": "kendryte-sdk-0.5.6.zip"
     },
     {
       "version": "v0.5.7",
-      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk.git",
-      "filename": "kendryte-sdk-0.5.7.zip",
-      "VER_SHA": "v0.5.7"
+      "URL": "https://github.com/RT-Thread-packages/kendryte_sdk/archive/v0.5.7.zip",
+      "filename": "kendryte-sdk-0.5.7.zip"
     },
     {
       "version": "latest",

--- a/peripherals/lora_gw_driver_lib/package.json
+++ b/peripherals/lora_gw_driver_lib/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/forest-rain/lora-gw-driver-lib.git",
       "filename": "Null for git package",
-      "VER_SHA": "fill in latest version branch name, such as master"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/peripherals/lora_modem_driver/package.json
+++ b/peripherals/lora_modem_driver/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/Forest-Rain/lora-modem-driver.git",
       "filename": "Null for git package",
-      "VER_SHA": "fill in latest version branch name, such as master"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/peripherals/mb85rs16/package.json
+++ b/peripherals/mb85rs16/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/XiaojieFan/mb85rs16.git",
       "filename": "Null for git package",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/mcp23008/package.json
+++ b/peripherals/mcp23008/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/XiaojieFan/mcp23008.git",
       "filename": "Null for git package",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/pca9685/package.json
+++ b/peripherals/pca9685/package.json
@@ -19,12 +19,6 @@
   "doc": "unknown",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/greedyhao/pca9685.git",
-      "filename": "pca9685-1.0.0.zip",
-      "VER_SHA": "NULL"
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/greedyhao/pca9685.git",
       "filename": "Null for git package",

--- a/peripherals/rs232/package.json
+++ b/peripherals/rs232/package.json
@@ -21,12 +21,6 @@
   "doc": "https://github.com/diskwu/RTTHREAD_RS232/blob/main/readme.md",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/diskwu/RTTHREAD_RS232.git",
-      "filename": "rs232-1.0.0.zip",
-      "VER_SHA": ""
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/diskwu/RTTHREAD_RS232.git",
       "filename": "",

--- a/peripherals/sensors/balance/package.json
+++ b/peripherals/sensors/balance/package.json
@@ -22,7 +22,7 @@
       "version": "latest",
       "URL": "https://github.com/xiaogeminghai/balance.git",
       "filename": "", 
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/sensors/lis2dh12/package.json
+++ b/peripherals/sensors/lis2dh12/package.json
@@ -20,17 +20,10 @@
   "doc": "unknown",
   "site": [
     {
-      "version": "v0.0.1",
-      "URL": "https://github.com/StackRyan/lis2dh12.git",
-      "filename": "lis2dh12-0.0.1.zip",
-      "VER_SHA": ""
-    },
-    {
-      "version": "latest",
       "version": "latest",
       "URL": "https://github.com/StackRyan/lis2dh12.git",
-      "filename": "Null for git package",
-      "VER_SHA": "master"
+      "filename": "lis2dh12-latest.zip",
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/sensors/mlx90392/package.json
+++ b/peripherals/sensors/mlx90392/package.json
@@ -19,12 +19,6 @@
   "doc": "unknown",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/lgnq/mlx90392.git",
-      "filename": "mlx90392-1.0.0.zip",
-      "VER_SHA": "1da939f44ab90cab9b2119d65b11139c91808741"
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/lgnq/mlx90392.git",
       "filename": "mlx90392.zip",

--- a/peripherals/sensors/mlx90397/package.json
+++ b/peripherals/sensors/mlx90397/package.json
@@ -19,12 +19,6 @@
   "doc": "unknown",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/lgnq/mlx90397.git",
-      "filename": "mlx90397-1.0.0.zip",
-      "VER_SHA": ""
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/lgnq/mlx90397.git",
       "filename": "mlx90397.zip",

--- a/peripherals/sensors/ms5805/package.json
+++ b/peripherals/sensors/ms5805/package.json
@@ -20,9 +20,8 @@
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://github.com/schuck-wang/RTThread-MS5805.git",
-      "filename": "RTThread-MS5805-1.0.0.zip",
-      "VER_SHA": "NULL"
+      "URL": "https://github.com/schuck-wang/RTThread-MS5805/archive/refs/tags/v1.0.0.zip",
+      "filename": "RTThread-MS5805-1.0.0.zip"
     },
     {
       "version": "latest",

--- a/peripherals/sensors/sht4x/package.json
+++ b/peripherals/sensors/sht4x/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/flyingcys/sht4x.git",
       "filename": "sht4x.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/sensors/vl53l0x/package.json
+++ b/peripherals/sensors/vl53l0x/package.json
@@ -34,7 +34,7 @@
       "version": "latest",
       "URL": "https://github.com/Prry/rtt-vl53l0x.git",
       "filename": "vl53l0x-latest.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/sgm706/package.json
+++ b/peripherals/sgm706/package.json
@@ -31,7 +31,7 @@
       "version": "latest",
       "URL": "https://github.com/Prry/rtt-sgm706.git",
       "filename": "sgm706-latest.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/tca9534/package.json
+++ b/peripherals/tca9534/package.json
@@ -31,7 +31,7 @@
       "version": "latest",
       "URL": "https://github.com/Prry/rtt-tca9534.git",
       "filename": "tca9534-latest.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/peripherals/touch/gt917s/package.json
+++ b/peripherals/touch/gt917s/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/lilisheng411527/gt917s.git",
       "filename": "latest",
-      "VER_SHA": "latest"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/system/CMSIS/CMSIS_RTOS1/package.json
+++ b/system/CMSIS/CMSIS_RTOS1/package.json
@@ -21,7 +21,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/CMSIS_RTOS1.git",
       "filename": "Null for git package",
-      "VER_SHA": "main"
+      "VER_SHA": "master"
     }
   ]
 }

--- a/system/Micrium/uCOSIII_Wrapper/package.json
+++ b/system/Micrium/uCOSIII_Wrapper/package.json
@@ -24,9 +24,8 @@
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://github.com/mysterywolf/RT-Thread-wrapper-of-uCOS-III.git",
-      "filename": "uCOSIII_Wrapper-1.0.0.zip",
-      "VER_SHA": "fill in the git version SHA value"
+      "URL": "https://github.com/mysterywolf/RT-Thread-wrapper-of-uCOS-III/archive/v1.0.0.zip",
+      "filename": "uCOSIII_Wrapper-1.0.0.zip"
     },
     {
       "version": "latest",

--- a/system/Micrium/uCOSII_Wrapper/package.json
+++ b/system/Micrium/uCOSII_Wrapper/package.json
@@ -24,9 +24,8 @@
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://github.com/mysterywolf/RT-Thread-wrapper-of-uCOS-II.git",
-      "filename": "uCOSII_Wrapper-1.0.0.zip",
-      "VER_SHA": "fill in the git version SHA value"
+      "URL": "https://github.com/mysterywolf/RT-Thread-wrapper-of-uCOS-II/archive/v1.0.0.zip",
+      "filename": "uCOSII_Wrapper-1.0.0.zip"
     },
     {
       "version": "latest",

--- a/system/Micrium/uC_CLK/package.json
+++ b/system/Micrium/uC_CLK/package.json
@@ -20,12 +20,6 @@
   "doc": "https://github.com/mysterywolf/uC-Clk-for-RT-Thread#readme",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/mysterywolf/uC-Clk-for-RT-Thread.git",
-      "filename": "uC_CLK-1.0.0.zip",
-      "VER_SHA": "fill in the git version SHA value"
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/mysterywolf/uC-Clk-for-RT-Thread.git",
       "filename": "Null for git package",

--- a/system/Micrium/uC_CRC/package.json
+++ b/system/Micrium/uC_CRC/package.json
@@ -20,12 +20,6 @@
   "doc": "https://github.com/mysterywolf/uC-CRC-for-RT-Thread#readme",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/mysterywolf/uC-CRC-for-RT-Thread.git",
-      "filename": "uC_CRC-1.0.0.zip",
-      "VER_SHA": "fill in the git version SHA value"
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/mysterywolf/uC-CRC-for-RT-Thread.git",
       "filename": "Null for git package",

--- a/system/Micrium/uC_Common/package.json
+++ b/system/Micrium/uC_Common/package.json
@@ -20,12 +20,6 @@
   "doc": "https://github.com/mysterywolf/uC-Common-for-RT-Thread#readme",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/mysterywolf/uC-Common-for-RT-Thread.git",
-      "filename": "uC_Common-1.0.0.zip",
-      "VER_SHA": "fill in the git version SHA value"
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/mysterywolf/uC-Common-for-RT-Thread.git",
       "filename": "Null for git package",

--- a/system/Micrium/uC_Modbus/package.json
+++ b/system/Micrium/uC_Modbus/package.json
@@ -21,12 +21,6 @@
   "doc": "https://github.com/mysterywolf/uC-Modbus-for-RT-Thread#readme",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/mysterywolf/uC-Modbus-for-RT-Thread.git",
-      "filename": "uC_Modbus-1.0.0.zip",
-      "VER_SHA": "fill in the git version SHA value"
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/mysterywolf/uC-Modbus-for-RT-Thread.git",
       "filename": "Null for git package",

--- a/system/lpm/package.json
+++ b/system/lpm/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/LPM.git",
       "filename": "lpm.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/ChineseFontLibrary/package.json
+++ b/tools/ChineseFontLibrary/package.json
@@ -17,12 +17,6 @@
   "homepage": "https://github.com/lxzzzzzxl/Chinese_font_library#README",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/lxzzzzzxl/Chinese_font_library.git",
-      "filename": "Chinese_font_library-1.0.0.zip",
-      "VER_SHA": ""
-    },
-    {
       "version": "latest",
       "URL": "https://github.com/lxzzzzzxl/Chinese_font_library.git",
       "filename": "Null for git package",

--- a/tools/Micro-XRCE-DDS-Client/package.json
+++ b/tools/Micro-XRCE-DDS-Client/package.json
@@ -24,7 +24,7 @@
       "version": "latest",
       "URL": "https://github.com/JcZou/Micro-XRCE-DDS-Client.git",
       "filename": "",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/SEGGER_RTT/package.json
+++ b/tools/SEGGER_RTT/package.json
@@ -35,7 +35,7 @@
       "version": "latest",
       "URL": "https://github.com/supperthomas/RTTHREAD_SEGGER_TOOL.git",
       "filename": "Null for git package",
-      "VER_SHA": "fill in latest version branch name, such as master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/fdt/package.json
+++ b/tools/fdt/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/fdt.git",
       "filename": "fdt.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/kdb/package.json
+++ b/tools/kdb/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/kdb.git",
       "filename": "Null for git package",
-      "VER_SHA": "fill in latest version branch name, such as master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/logmgr/package.json
+++ b/tools/logmgr/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/logmgr.git",
       "filename": "logmgr.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/rtt_auto_exe_cmd/package.json
+++ b/tools/rtt_auto_exe_cmd/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/supperthomas/RTT_AUTO_EXE_CMD.git",
       "filename": "",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/snowflake/package.json
+++ b/tools/snowflake/package.json
@@ -21,8 +21,8 @@
     {
       "version": "latest",
       "URL": "https://github.com/2022alpha/snowflake.git",
-      "filename": "snowflake-master.zip",
-      "VER_SHA": "master"
+      "filename": "snowflake-main.zip",
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/ulog_file/package.json
+++ b/tools/ulog_file/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/RT-Thread-packages/ulog_file.git",
       "filename": "ulog_file.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/vconsole/package.json
+++ b/tools/vconsole/package.json
@@ -28,7 +28,7 @@
       "version": "latest",
       "URL": "https://github.com/enkiller/vconsole.git",
       "filename": "Null for git package",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }

--- a/tools/vofa_plus/package.json
+++ b/tools/vofa_plus/package.json
@@ -22,7 +22,7 @@
       "version": "latest",
       "URL": "https://github.com/xiaogeminghai/vofa_plus.git",
       "filename": "", 
-      "VER_SHA": "master" 
+      "VER_SHA": "main" 
     }
   ]
 }

--- a/tools/zdebug/package.json
+++ b/tools/zdebug/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/beisongcrt/zdebug.git",
       "filename": "",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }


### PR DESCRIPTION
问题来源：
https://github.com/RT-Thread/packages/pull/1654

## 问题描述：

在向软件包索引添加或修改软件包的时候可能会遇到一些问题。
比如，发布的分支名填错了，导致找不到对应的分支。
填了一个github仓库地址，但是结尾不是.git, 这时候会识别为一个文件下载链接，但是下载不到文件。

## 解决方法：
在ci.py里面添加对这个问题的检查。
检查分支名是否存在，如果不存在就检查commit SHA是不是存在，否则报错。
如果不是.git结尾那么就是一个文件链接，这时候检查是不是一个文件链接。

## 经过检查后，软件包索引源就现在有一些问题：
https://github.com/RT-Thread/packages/commit/0521b42828376f525a3482ab798be2bc3de48807
一些软件包的某个版本的URL不正确，修改了这些URL指向了正确的地址。 

https://github.com/RT-Thread/packages/commit/21bc7298833420567702c3752d100f0870684f41
一些软件包的latest版本对应的分支不正确，修改了这些指向了正确的分支。

https://github.com/RT-Thread/packages/commit/8a2708e6e8a9d263012d0c2ce0f25e7b061f3fb3
一些软件包的某个版本写了git地址，没有写对应的分支，仓库里面也找不到对应的版本，于是我删除了这些版本。
https://github.com/lgnq/mlx90392
这个软件包的v1.0.0版本指向的commit sha不存在，于是我删除了这个版本。