### PR TITLE
add lhc-modbus package index

### DIFF
--- a/iot/Kconfig
+++ b/iot/Kconfig
@@ -64,4 +64,5 @@ source "$PKGS_DIR/packages/iot/zFTP/Kconfig"
 source "$PKGS_DIR/packages/iot/wol/Kconfig"
 source "$PKGS_DIR/packages/iot/zephyr_polling/Kconfig"
 source "$PKGS_DIR/packages/iot/matter-adaptation-layer/Kconfig"
+source "$PKGS_DIR/packages/iot/lhc_modbus/Kconfig"
 endmenu

--- a/iot/lhc_modbus/Kconfig
+++ b/iot/lhc_modbus/Kconfig
@@ -1,0 +1,36 @@
+
+# Kconfig file for package lhc_modbus
+menuconfig PKG_USING_LHC_MODBUS
+    bool "Lightweight and high-performance C language modbus protocol stack."
+    default n
+
+if PKG_USING_LHC_MODBUS
+
+    config PKG_LHC_MODBUS_PATH
+        string
+        default "/packages/iot/lhc_modbus"
+		
+	config LHC_MODBUS_USING_SAMPLES
+        bool "Enable samples"
+        default n
+
+    choice
+        prompt "Version"
+        default PKG_USING_LHC_MODBUS_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_LHC_MODBUS_V100
+            bool "v1.0.0"
+
+        config PKG_USING_LHC_MODBUS_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_LHC_MODBUS_VER
+       string
+       default "v1.0.0"    if PKG_USING_LHC_MODBUS_V100
+       default "latest"    if PKG_USING_LHC_MODBUS_LATEST_VERSION
+	   
+endif
+

--- a/iot/lhc_modbus/package.json
+++ b/iot/lhc_modbus/package.json
@@ -20,7 +20,7 @@
   "site": [
     {
       "version": "v1.0.0",
-      "URL": "https://github.com/LHC324/lhc_modbus/archive/V1.0.0.zip",
+      "URL": "https://github.com/LHC324/lhc_modbus/archive/v1.0.0.zip",
       "filename": "lhc_modbus-1.0.0.zip"
     },
     {

--- a/iot/lhc_modbus/package.json
+++ b/iot/lhc_modbus/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "lhc_modbus",
+  "description": "Lightweight and high-performance C language modbus protocol stack.",
+  "description_zh": "轻量级和高性能的C语言modbus协议栈。",
+  "enable": "PKG_USING_LHC_MODBUS",
+  "keywords": [
+    "lhc_modbus"
+  ],
+  "category": "iot",
+  "author": {
+    "name": "LHC324",
+    "email": "1606820017@qq.com",
+    "github": "LHC324"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/LHC324/lhc_modbus",
+  "icon": "unknown",
+  "homepage": "https://github.com/LHC324/lhc_modbus#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/LHC324/lhc_modbus/archive/V1.0.0.zip",
+      "filename": "lhc_modbus-1.0.0.zip"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/LHC324/lhc_modbus.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
添加一个软件包“lhc_modbus”的索引到package仓库，需要管理人员批准一下工作流。