### PR TITLE
[add package] cst812t capacitive touch package.

### DIFF
--- a/peripherals/touch/Kconfig
+++ b/peripherals/touch/Kconfig
@@ -9,5 +9,6 @@ source "$PKGS_DIR/packages/peripherals/touch/ft5426/Kconfig"
 source "$PKGS_DIR/packages/peripherals/touch/ft6236/Kconfig"
 source "$PKGS_DIR/packages/peripherals/touch/xpt2046/Kconfig"
 source "$PKGS_DIR/packages/peripherals/touch/cst816x/Kconfig"
+source "$PKGS_DIR/packages/peripherals/touch/cst812t/Kconfig"
 
 endmenu

--- a/peripherals/touch/cst812t/Kconfig
+++ b/peripherals/touch/cst812t/Kconfig
@@ -1,0 +1,33 @@
+
+# Kconfig file for package cst812t
+menuconfig PKG_USING_CST812T
+    bool "cst812t touch ic for RT-Thread's TrackPad"
+    select RT_USING_I2C
+    select RT_USING_TOUCH
+    default n
+
+if PKG_USING_CST812T
+
+    config PKG_CST812T_PATH
+        string
+        default "/packages/peripherals/touch/cst812t"
+
+    config PKG_USING_CST812T_EXAMPLE
+        bool "Use example demo touch data reading"
+        default n
+
+    choice
+        prompt "Version"
+        help
+            Select the package version
+
+        config PKG_USING_CST812T_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_CST812T_VER
+       string
+       default "latest"    if PKG_USING_CST812T_LATEST_VERSION
+
+endif
+

--- a/peripherals/touch/cst812t/package.json
+++ b/peripherals/touch/cst812t/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "cst812t",
+  "description": "cst812t drivers for RT-Thread",
+  "description_zh": "cst812t 触摸芯片驱动程序。",
+  "enable": "PKG_USING_CST812T",
+  "keywords": [
+    "cst812t",
+    "touch"
+  ],
+  "category": "peripherals/touch",
+  "author": {
+    "name": "StackYuan",
+    "email": "yuanjyjyj@outlook.com",
+    "github": "StackYuan"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/StackYuan/cst812t",
+  "icon": "unknown",
+  "homepage": "https://github.com/StackYuan/cst812t#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/StackYuan/cst812t.git",
+      "filename": "",
+      "VER_SHA": "main"
+    }
+  ]
+}


### PR DESCRIPTION
[add package] cst812t capacitive touch package for RT-Thread 2.0 inch TrackPad.