### PR TITLE
add configure of iperf stack size

### DIFF
--- a/iot/netutils/Kconfig
+++ b/iot/netutils/Kconfig
@@ -49,6 +49,13 @@ if PKG_USING_NETUTILS
         select RT_USING_POSIX_SOCKET    if RT_VER_NUM >= 0x40100
         default n
 
+    if PKG_NETUTILS_IPERF
+        config IPERF_THREAD_STACK_SIZE
+            int "the stack size of iperf thread"
+            range 2048 65536
+            default 2048
+    endif
+
     config PKG_NETUTILS_NETIO
         bool "Enable NetIO network throughput performance tool"
         default n

--- a/iot/netutils/Kconfig
+++ b/iot/netutils/Kconfig
@@ -49,12 +49,12 @@ if PKG_USING_NETUTILS
         select RT_USING_POSIX_SOCKET    if RT_VER_NUM >= 0x40100
         default n
 
-    if PKG_NETUTILS_IPERF
-        config IPERF_THREAD_STACK_SIZE
-            int "the stack size of iperf thread"
-            range 2048 65536
-            default 2048
-    endif
+    config IPERF_THREAD_STACK_SIZE
+        int "the stack size of iperf thread"
+        depends on PKG_NETUTILS_IPERF
+        range 2048 65536
+        default 16384 if ARCH_CPU_64BIT
+        default 2048
 
     config PKG_NETUTILS_NETIO
         bool "Enable NetIO network throughput performance tool"


### PR DESCRIPTION
aarch64平台iperf栈大小需大于2048，否则栈溢出

关联pr: https://github.com/RT-Thread-packages/netutils/pull/98