### PR TITLE
fix speedmode value of tinyusb

### DIFF
--- a/system/TinyUSB/Kconfig
+++ b/system/TinyUSB/Kconfig
@@ -58,8 +58,8 @@ if PKG_USING_TINYUSB
 
     config PKG_TINYUSB_DEVICE_PORT_SPEED
         hex
-        default 0x00 if PKG_TINYUSB_FULL_SPEED
-        default 0x20 if PKG_TINYUSB_HIGH_SPEED
+        default 0x0200 if PKG_TINYUSB_FULL_SPEED
+        default 0x0400 if PKG_TINYUSB_HIGH_SPEED
 
     menuconfig PKG_TINYUSB_DEVICE_ENABLE
         bool "Using USB device"


### PR DESCRIPTION
the speedmode should be use the below value
from latest version

https://github.com/RT-Thread-packages/tinyusb/blob/e253d517f0d308e6c072afb6e7952112f3e0d1f9/src/tusb_option.h#L203C1-L206C55
