### PR TITLE
[sensor] sensor mode separation

### DIFF
--- a/peripherals/sensors/dht11/Kconfig
+++ b/peripherals/sensors/dht11/Kconfig
@@ -14,6 +14,11 @@ if PKG_USING_DHT11
         string
         default "/packages/peripherals/sensors/dht11"
 
+    config PKG_DHT11_USING_SENSOR_V1
+        bool "Enable sensor divce framework"
+        select RT_USING_SENSOR
+        default n
+
     choice
         prompt "Version"
         default PKG_USING_DHT11_LATEST_VERSION


### PR DESCRIPTION
Adjust the structure of the sensor software package and divide it into two versions: Sensor framework driver and driver framework driver. The sensor version driver is used only after the user opens the sensor framework, and the driver examples of the two versions are provided.