### PR TITLE
[update]更新RW007 软件包Kconfig，在选定V2.1.0 版本和latest 版本可选RW007 的BLE 功能、开关省电…

### DIFF
--- a/iot/WiFi/rw007/Kconfig
+++ b/iot/WiFi/rw007/Kconfig
@@ -64,6 +64,18 @@ if PKG_USING_RW007
         #    bool "rw007 for imxrt"
     endchoice
 
+    if PKG_USING_RW007_V210 || PKG_USING_RW007_LATEST_VERSION
+        config RW007_USING_BLE
+                bool "rw007 using ble"
+                default n
+        config RW007_USING_POWERSWITCH_EXAMPLE
+                bool "rw007 using powerswitch example"
+                default n
+        config RW007_USING_SPI_TEST
+                bool "rw007 using spi test"
+                default n
+    endif
+
     config RW007_SPI_MAX_HZ
         int "SPI Max Hz"
         default 30000000


### PR DESCRIPTION
更新RW007 软件包Kconfig，在选定V2.1.0 版本和latest 版本可选RW007 的BLE 功能、开关省电示例、开启SPI 吞吐量测试功能。