### PR TITLE
[respository] modify master to main which not have master

### DIFF
--- a/peripherals/sensors/mlx90392/package.json
+++ b/peripherals/sensors/mlx90392/package.json
@@ -22,7 +22,7 @@
       "version": "latest",
       "URL": "https://github.com/lgnq/mlx90392.git",
       "filename": "mlx90392.zip",
-      "VER_SHA": "master"
+      "VER_SHA": "main"
     }
   ]
 }


### PR DESCRIPTION
mlx90392 仓库地址不存在 master ，更改为main