### PR TITLE
[peripherals] add a new software package rtt-gc9a01 in peripherals

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -77,6 +77,7 @@ source "$PKGS_DIR/packages/peripherals/System_Run_LED/Kconfig"
 source "$PKGS_DIR/packages/peripherals/bt_mx01/Kconfig"
 source "$PKGS_DIR/packages/peripherals/RgPower/Kconfig"
 source "$PKGS_DIR/packages/peripherals/bt_mx02/Kconfig"
+source "$PKGS_DIR/packages/peripherals/gc9a01/Kconfig"
 
 if RT_VER_NUM > 0x40101
 source "$PKGS_DIR/packages/peripherals/spi-tools/Kconfig"

--- a/peripherals/gc9a01/Kconfig
+++ b/peripherals/gc9a01/Kconfig
@@ -1,7 +1,7 @@
 
 # Kconfig file for package gc9a01
 menuconfig PKG_USING_GC9A01
-    bool "gc9a01: OLEDs based on GC9A01, SH1106, SH1107 and SSD1309 driver"
+    bool "gc9a01: RT-Thread package for working with TFT LCD based on SPI."
     default n
 
 if PKG_USING_GC9A01
@@ -10,24 +10,20 @@ if PKG_USING_GC9A01
         string
         default "/packages/peripherals/gc9a01"
 
-    config PKG_USING_GC9A01_DEBUG
-        bool "Enable debug log output"
-        default n
-
     config PKG_USING_GC9A01_SPI_BUS_NAME
         string "SPI bus name"
         default "spi0"
 
     config PKG_USING_GC9A01_DC_PIN
-        int "DC PIN for example : 3*32+1"
+        int "DC PIN number for example : 3*32+1"
         default "97"
 
     config PKG_USING_GC9A01_RES_PIN
-        int "RES PIN for example : 3*32+30"
+        int "RES PIN number for example : 3*32+30"
         default "126"
 
     config PKG_USING_GC9A01_CS_PIN
-        int "CS PIN for example : 1*32+3"
+        int "CS PIN number for example : 1*32+3"
         default "35"
 
     config PKG_USING_GC9A01_SAMPLE

--- a/peripherals/gc9a01/Kconfig
+++ b/peripherals/gc9a01/Kconfig
@@ -36,16 +36,12 @@ if PKG_USING_GC9A01
         help
             Select the package version
 
-        config PKG_USING_GC9A01_V100
-            bool "v1.0.0"
-
         config PKG_USING_GC9A01_LATEST_VERSION
             bool "latest"
     endchoice
 
     config PKG_GC9A01_VER
        string
-       default "v1.0.0"    if PKG_USING_GC9A01_V100
        default "latest"    if PKG_USING_GC9A01_LATEST_VERSION
 
 endif

--- a/peripherals/gc9a01/Kconfig
+++ b/peripherals/gc9a01/Kconfig
@@ -15,15 +15,15 @@ if PKG_USING_GC9A01
         default "spi0"
 
     config PKG_USING_GC9A01_DC_PIN
-        int "DC PIN number for example : 3*32+1"
+        int "DC PIN number for example in frdm-mcxa153 board P3_1 -> 3*32+1"
         default "97"
 
     config PKG_USING_GC9A01_RES_PIN
-        int "RES PIN number for example : 3*32+30"
+        int "RES PIN number for example in frdm-mcxa153 board P3_30 -> 3*32+30"
         default "126"
 
     config PKG_USING_GC9A01_CS_PIN
-        int "CS PIN number for example : 1*32+3"
+        int "CS PIN number for example in frdm-mcxa153 board P1_3 -> 1*32+3"
         default "35"
 
     config PKG_USING_GC9A01_SAMPLE

--- a/peripherals/gc9a01/Kconfig
+++ b/peripherals/gc9a01/Kconfig
@@ -14,13 +14,21 @@ if PKG_USING_GC9A01
         bool "Enable debug log output"
         default n
 
-    config PKG_USING_GC9A01_I2C_ADDRESS
-       hex "I2C address"
-       default 0x3C
+    config PKG_USING_GC9A01_SPI_BUS_NAME
+        string "SPI bus name"
+        default "spi0"
 
-    config PKG_USING_GC9A01_I2C_BUS_NAME
-        string "I2C bus name"
-        default "i2c1"
+    config PKG_USING_GC9A01_DC_PIN
+        int "DC PIN"
+        default "0"
+
+    config PKG_USING_GC9A01_RES_PIN
+        int "RES PIN"
+        default "0"
+
+    config PKG_USING_GC9A01_CS_PIN
+        int "CS PIN"
+        default "0"
 
     config PKG_USING_GC9A01_SAMPLE
         bool "Enable gc9a01 sample"

--- a/peripherals/gc9a01/Kconfig
+++ b/peripherals/gc9a01/Kconfig
@@ -19,16 +19,16 @@ if PKG_USING_GC9A01
         default "spi0"
 
     config PKG_USING_GC9A01_DC_PIN
-        int "DC PIN"
-        default "0"
+        int "DC PIN for example : 3*32+1"
+        default "97"
 
     config PKG_USING_GC9A01_RES_PIN
-        int "RES PIN"
-        default "0"
+        int "RES PIN for example : 3*32+30"
+        default "126"
 
     config PKG_USING_GC9A01_CS_PIN
-        int "CS PIN"
-        default "0"
+        int "CS PIN for example : 1*32+3"
+        default "35"
 
     config PKG_USING_GC9A01_SAMPLE
         bool "Enable gc9a01 sample"

--- a/peripherals/gc9a01/Kconfig
+++ b/peripherals/gc9a01/Kconfig
@@ -1,0 +1,48 @@
+
+# Kconfig file for package gc9a01
+menuconfig PKG_USING_GC9A01
+    bool "gc9a01: OLEDs based on GC9A01, SH1106, SH1107 and SSD1309 driver"
+    default n
+
+if PKG_USING_GC9A01
+
+    config PKG_GC9A01_PATH
+        string
+        default "/packages/peripherals/gc9a01"
+
+    config PKG_USING_GC9A01_DEBUG
+        bool "Enable debug log output"
+        default n
+
+    config PKG_USING_GC9A01_I2C_ADDRESS
+       hex "I2C address"
+       default 0x3C
+
+    config PKG_USING_GC9A01_I2C_BUS_NAME
+        string "I2C bus name"
+        default "i2c1"
+
+    config PKG_USING_GC9A01_SAMPLE
+        bool "Enable gc9a01 sample"
+        default n
+
+    choice
+        prompt "Version"
+        default PKG_USING_GC9A01_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_GC9A01_V100
+            bool "v1.0.0"
+
+        config PKG_USING_GC9A01_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_GC9A01_VER
+       string
+       default "v1.0.0"    if PKG_USING_GC9A01_V100
+       default "latest"    if PKG_USING_GC9A01_LATEST_VERSION
+
+endif
+

--- a/peripherals/gc9a01/package.json
+++ b/peripherals/gc9a01/package.json
@@ -1,11 +1,12 @@
 {
   "name": "gc9a01",
-  "description": "gc9a01: RT-Thread package for working with OLED based on  SPI.",
-  "description_zh": "基于gc9a01的 OLED 驱动，支持SPI",
+  "description": "gc9a01: RT-Thread package for working with TFT LCD based on SPI.",
+  "description_zh": "基于gc9a01的圆形TFT LCD驱动，支持SPI",
   "enable": "PKG_USING_GC9A01",
   "keywords": [
     "gc9a01",
-    "oled"
+    "tft",
+    "lcd"
   ],
   "category": "peripherals",
   "author": {
@@ -14,19 +15,14 @@
     "github": "hywing"
   },
   "license": "Apache-2.0",
-  "repository": "https://github.com/hywing/tft-gc9a01",
+  "repository": "https://github.com/hywing/rtt-gc9a01",
   "icon": "unknown",
-  "homepage": "https://github.com/hywing/tft-gc9a01",
+  "homepage": "https://github.com/hywing/rtt-gc9a01",
   "doc": "unknown",
   "site": [
     {
-      "version": "v1.0.0",
-      "URL": "https://github.com/hywing/tft-gc9a01/archive/v1.0.0.zip",
-      "filename": "gc9a01-1.0.0.zip"
-    },
-    {
       "version": "latest",
-      "URL": "https://github.com/hywing/tft-gc9a01.git",
+      "URL": "https://github.com/hywing/rtt-gc9a01.git",
       "filename": "gc9a01-latest.zip",
       "VER_SHA": "main"
     }

--- a/peripherals/gc9a01/package.json
+++ b/peripherals/gc9a01/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "gc9a01",
+  "description": "gc9a01: RT-Thread package for working with OLED based on  SPI.",
+  "description_zh": "基于gc9a01的 OLED 驱动，支持SPI",
+  "enable": "PKG_USING_GC9A01",
+  "keywords": [
+    "gc9a01",
+    "oled"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "hywing",
+    "email": "hywing@aliyum.com",
+    "github": "hywing"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/hywing/tft-gc9a01",
+  "icon": "unknown",
+  "homepage": "https://github.com/hywing/tft-gc9a01",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/hywing/tft-gc9a01/archive/v1.0.0.zip",
+      "filename": "gc9a01-1.0.0.zip"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/hywing/tft-gc9a01.git",
+      "filename": "gc9a01-latest.zip",
+      "VER_SHA": "main"
+    }
+  ]
+}


### PR DESCRIPTION
RT-Thread package for working with TFT LCD based on  SPI, the IC is gc9a01.