### PR TITLE
[misc/samples/kernel_samples] dele the Kconfig of KERNEL_SAMPLES_USIN…

### DIFF
--- a/misc/samples/kernel_samples/Kconfig
+++ b/misc/samples/kernel_samples/Kconfig
@@ -69,9 +69,6 @@ if PKG_USING_KERNEL_SAMPLES
     config KERNEL_SAMPLES_USING_HEAP
         bool "[kernel] heap"
 
-    config KERNEL_SAMPLES_USING_MEMHEAP
-        bool "[kernel] memheap"
-
     config KERNEL_SAMPLES_USING_MEMPOOL
         bool "[kernel] mempool"
 


### PR DESCRIPTION
…G_MEMHEAP,whitch can`n be used in the complier.