### PR TITLE
新增 sean_ws2812b 软件包

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -80,6 +80,7 @@ source "$PKGS_DIR/packages/peripherals/bt_mx02/Kconfig"
 source "$PKGS_DIR/packages/peripherals/gc9a01/Kconfig"
 source "$PKGS_DIR/packages/peripherals/ikun-485/Kconfig"
 source "$PKGS_DIR/packages/peripherals/Servo_sg90/Kconfig"
+source "$PKGS_DIR/packages/peripherals/sean_ws2812b/Kconfig"
 
 if RT_VER_NUM > 0x40101
 source "$PKGS_DIR/packages/peripherals/spi-tools/Kconfig"

--- a/peripherals/sean_ws2812b/Kconfig
+++ b/peripherals/sean_ws2812b/Kconfig
@@ -1,0 +1,62 @@
+# Kconfig file for package sean_ws2812b
+menuconfig PKG_USING_SEAN_WS2812B
+    bool "Sean's WS2812B LED Driver Package"
+    default n
+
+if PKG_USING_SEAN_WS2812B
+
+    config PKG_SEAN_WS2812B_PATH
+        string
+        default "/packages/peripherals/sean_ws2812b"
+
+    choice
+        prompt "Version"
+        help
+            Select the version of sean_ws2812b
+
+        config PKG_USING_SEAN_WS2812B_LATEST
+            bool "latest version (master branch)"
+
+    endchoice
+
+    config PKG_SEAN_WS2812B_VER
+        string
+        default "latest" if PKG_USING_SEAN_WS2812B_LATEST
+
+    config SEAN_WS2812B_SPI_BUS_NAME
+        string "SPI bus name (master)"
+        default "spi1"
+        help
+            SPI bus (controller) name for WS2812B, e.g., 'spi1'.
+
+    config SEAN_WS2812B_SPI_DEV_NAME
+        string "SPI device name (slave)"
+        default "spi10"
+        help
+            SPI device name for WS2812B, e.g., 'spi10'.
+
+    config SEAN_WS2812B_SPI_CS_PORT
+        string "SPI CS GPIO port"
+        default "GPIOB"
+        help
+            SPI CS GPIO port for WS2812B, e.g., 'GPIOB'.
+
+    config SEAN_WS2812B_SPI_CS_PIN
+        int "SPI CS GPIO pin number"
+        default 12
+        help
+            SPI CS GPIO pin number for WS2812B, e.g., 12.
+
+    config SEAN_WS2812B_LED_NUMS
+        int "Number of LEDs"
+        default 5
+        help
+            Set the number of LEDs on the WS2812B strip.
+
+    config SEAN_WS2812B_USING_DEMO
+        bool "Enable demo examples"
+        default n
+        help
+            Enable demo examples for WS2812B.
+
+endif

--- a/peripherals/sean_ws2812b/package.json
+++ b/peripherals/sean_ws2812b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "sean_ws2812b",
+  "description": "Complete WS2812B LED Strip Driver based on SPI for RT-Thread 4.1.0",
+  "description_zh": "基于SPI接口的WS2812B灯带驱动软件包,适用于RT-Thread 4.1.0系统。",
+  "enable": "PKG_USING_SEAN_WS2812B",
+  "keywords": [
+    "ws2812b",
+    "rgb"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "godmial",
+    "email": "2633967641@qq.com",
+    "github": "godmial"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/godmial/sean_ws2812b.git",
+  "icon": "https://raw.githubusercontent.com/godmial/sean_ws2812b/main/icon.png",
+  "homepage": "https://github.com/godmial/sean_ws2812b#readme",
+  "doc": "https://github.com/godmial/sean_ws2812b#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/godmial/sean_ws2812b.git",
+      "filename": "sean_ws2812b.zip",
+      "VER_SHA": "main"
+    }
+  ]
+}


### PR DESCRIPTION
## 新增软件包：sean_ws2812b

### 简介
新增 sean_ws2812b 灯带驱动软件包，基于 SPI 接口控制 WS2812B RGB 灯带，适用于 RT-Thread 4.1.0 系统。

该软件包体积小巧、接口规范、功能完整，支持单颗灯珠控制、批量设置、全局亮度调整以及内置 Gamma 校正。

### 功能特性
- 支持通过 SPI 接口控制 WS2812B 灯带
- 支持单颗灯珠独立设置颜色
- 支持批量设置所有灯珠颜色
- 支持全局亮度调节（0~255）
- 支持 Gamma 矫正，亮度更自然
- 提供基础灯效示例（如流水灯、呼吸灯）
- 支持 Kconfig 配置 SPI 总线、设备名称、片选引脚、灯珠数量等参数
- 提供详细的 README.md 使用说明文档

### 适配平台
- 当前版本基于 RT-Thread 4.1.0 设计
- 实测平台：
  - STM32F103（主频48MHz）运行正常
  - STM32H743（主频68MHz）运行正常

### 使用说明
- 需要在 RT-Thread `menuconfig` 中开启 SPI 驱动（RT_USING_SPI）
- 在工程 `board.h` 文件中取消注释对应的 SPI 总线宏
- 在 STM32CubeMX 中配置 SPI 接口为 "半双工单向发送（Transmit Only Half Duplex）" 模式

详细使用方法和注意事项请参考软件包自带的 [README.md](https://github.com/godmial/sean_ws2812b#readme)。

### TODO清单
- [ ] 增加基于 PWM 方式的 WS2812B 驱动支持
- [ ] 适配 RT-Thread 5.1.0 及以上版本

### 许可协议
本软件包遵循 Apache-2.0 许可证。

---
