### PR TITLE
add nxp_imx的软件包仓库索引

### DIFF
--- a/peripherals/hal-sdk/nxp/Kconfig
+++ b/peripherals/hal-sdk/nxp/Kconfig
@@ -7,4 +7,10 @@ source "$PKGS_DIR/packages/peripherals/hal-sdk/nxp/nxp-mcx-series/Kconfig"
 # nxp-lpc
 source "$PKGS_DIR/packages/peripherals/hal-sdk/nxp/nxp-lpc-series/Kconfig"
 source "$PKGS_DIR/packages/peripherals/hal-sdk/nxp/nxp-lpc55s-series/Kconfig"
+
+# nxp-imx
+source "$PKGS_DIR/packages/peripherals/hal-sdk/nxp/nxp-imx6sx-sdk/Kconfig"
+source "$PKGS_DIR/packages/peripherals/hal-sdk/nxp/nxp-imx6ul-sdk/Kconfig"
+source "$PKGS_DIR/packages/peripherals/hal-sdk/nxp/nxp-imxrt-sdk/Kconfig"
+
 endmenu

--- a/peripherals/hal-sdk/nxp/nxp-imx6sx-sdk/Kconfig
+++ b/peripherals/hal-sdk/nxp/nxp-imx6sx-sdk/Kconfig
@@ -1,0 +1,27 @@
+
+# Kconfig file for package nxp-imx6sx-sdk
+menuconfig PKG_USING_NXP_IMX6SX_DRIVER
+    bool "NXP IMX6SX DRIVER PACKAGE"
+    default n
+
+if PKG_USING_NXP_IMX6SX_DRIVER
+
+    config PKG_NXP_IMX6SX_DRIVER_PATH
+        string
+        default "/packages/peripherals/hal-sdk/nxp/nxp-imx6sx-sdk"
+
+    choice
+        prompt "Version"
+        help
+            Select the package version
+
+        config PKG_USING_NXP_IMX6SX_DRIVER_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_NXP_IMX6SX_DRIVER_VER
+       string
+       default "latest"    if PKG_USING_NXP_IMX6SX_DRIVER_LATEST_VERSION
+
+endif
+

--- a/peripherals/hal-sdk/nxp/nxp-imx6sx-sdk/package.json
+++ b/peripherals/hal-sdk/nxp/nxp-imx6sx-sdk/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "nxp-imx6sx-sdk",
+  "description": "NXP IMX6SX DRIVER PACKAGE",
+  "description_zh": "NXP IMX6SX 驱动包",
+  "enable": "PKG_USING_NXP_IMX6SX_DRIVER",
+  "keywords": [
+    "nxp-imx6sx-sdk"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "RT-Thread-packages",
+    "email": "package_team@rt-thread.com",
+    "github": "RT-Thread-packages"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/RT-Thread-packages/nxp-imx6sx-sdk",
+  "icon": "unknown",
+  "homepage": "https://github.com/RT-Thread-packages/nxp-imx6sx-sdk#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/RT-Thread-packages/nxp-imx6sx-sdk.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}

--- a/peripherals/hal-sdk/nxp/nxp-imx6ul-sdk/Kconfig
+++ b/peripherals/hal-sdk/nxp/nxp-imx6ul-sdk/Kconfig
@@ -1,0 +1,27 @@
+
+# Kconfig file for package nxp-imx6ul-sdk
+menuconfig PKG_USING_NXP_IMX6UL_DRIVER
+    bool "NXP IMX6UL DRIVER PACKAGE"
+    default n
+
+if PKG_USING_NXP_IMX6UL_DRIVER
+
+    config PKG_NXP_IMX6UL_DRIVER_PATH
+        string
+        default "/packages/peripherals/hal-sdk/nxp/nxp-imx6ul-sdk"
+
+    choice
+        prompt "Version"
+        help
+            Select the package version
+
+        config PKG_USING_NXP_IMX6UL_DRIVER_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_NXP_IMX6UL_DRIVER_VER
+       string
+       default "latest"    if PKG_USING_NXP_IMX6UL_DRIVER_LATEST_VERSION
+
+endif
+

--- a/peripherals/hal-sdk/nxp/nxp-imx6ul-sdk/package.json
+++ b/peripherals/hal-sdk/nxp/nxp-imx6ul-sdk/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "nxp-imx6ul-sdk",
+  "description": "NXP IMX6UL DRIVER PACKAGE",
+  "description_zh": "NXP IMX6UL 驱动包",
+  "enable": "PKG_USING_NXP_IMX6UL_DRIVER",
+  "keywords": [
+    "nxp-imx6ul-sdk"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "RT-Thread-packages",
+    "email": "package_team@rt-thread.com",
+    "github": "RT-Thread-packages"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/RT-Thread-packages/nxp-imx6ul-sdk",
+  "icon": "unknown",
+  "homepage": "https://github.com/RT-Thread-packages/nxp-imx6ul-sdk#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/RT-Thread-packages/nxp-imx6ul-sdk.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}

--- a/peripherals/hal-sdk/nxp/nxp-imxrt-sdk/Kconfig
+++ b/peripherals/hal-sdk/nxp/nxp-imxrt-sdk/Kconfig
@@ -1,0 +1,27 @@
+
+# Kconfig file for package nxp-imxrt-sdk
+menuconfig PKG_USING_NXP_IMXRT_DRIVER
+    bool "NXP IMXRT DRIVER PACKAGE"
+    default n
+
+if PKG_USING_NXP_IMXRT_DRIVER
+
+    config PKG_NXP_IMXRT_DRIVER_PATH
+        string
+        default "/packages/peripherals/hal-sdk/nxp/nxp-imxrt-sdk"
+
+    choice
+        prompt "Version"
+        help
+            Select the package version
+
+        config PKG_USING_NXP_IMXRT_DRIVER_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_NXP_IMXRT_DRIVER_VER
+       string
+       default "latest"    if PKG_USING_NXP_IMXRT_DRIVER_LATEST_VERSION
+
+endif
+

--- a/peripherals/hal-sdk/nxp/nxp-imxrt-sdk/package.json
+++ b/peripherals/hal-sdk/nxp/nxp-imxrt-sdk/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "nxp-imxrt-sdk",
+  "description": "NXP IMXRT DRIVER PACKAGE",
+  "description_zh": "NXP IMXRT 驱动包",
+  "enable": "PKG_USING_NXP_IMXRT_DRIVER",
+  "keywords": [
+    "nxp-imxrt-sdk"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "RT-Thread-packages",
+    "email": "package_team@rt-thread.com",
+    "github": "RT-Thread-packages"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/RT-Thread-packages/nxp-imxrt-sdk",
+  "icon": "unknown",
+  "homepage": "https://github.com/RT-Thread-packages/nxp-imxrt-sdk#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/RT-Thread-packages/nxp-imxrt-sdk.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
其中包含的对应软件包仓库:
https://github.com/RT-Thread-packages/nxp-imx6sx-sdk/pull/1
https://github.com/RT-Thread-packages/nxp-imx6ul-sdk/pull/1
https://github.com/RT-Thread-packages/nxp-imxrt-sdk/pull/1