### PR TITLE
新增74HC165驱动

### DIFF
--- a/peripherals/Kconfig
+++ b/peripherals/Kconfig
@@ -81,6 +81,7 @@ source "$PKGS_DIR/packages/peripherals/gc9a01/Kconfig"
 source "$PKGS_DIR/packages/peripherals/ikun-485/Kconfig"
 source "$PKGS_DIR/packages/peripherals/Servo_sg90/Kconfig"
 source "$PKGS_DIR/packages/peripherals/sean_ws2812b/Kconfig"
+source "$PKGS_DIR/packages/peripherals/ic74hc165/Kconfig"
 
 if RT_VER_NUM > 0x40101
 source "$PKGS_DIR/packages/peripherals/spi-tools/Kconfig"

--- a/peripherals/ic74hc165/Kconfig
+++ b/peripherals/ic74hc165/Kconfig
@@ -1,0 +1,68 @@
+menuconfig PKG_USING_IC74HC165
+    bool "ic74hc165: 74HC165 GPIO/SPI 驱动"
+    depends on RT_USING_COMPONENTS_INIT
+    help
+      使用 GPIO 或 SPI 模式读取 74HC165 输入数据的驱动软件包
+
+if PKG_USING_IC74HC165
+
+choice
+    prompt "通信模式选择"
+    default PKG_IC74HC165_MODE_GPIO
+    help
+      选择使用 GPIO 模拟方式 或 SPI 外设方式驱动 74165
+
+config PKG_IC74HC165_MODE_GPIO
+    bool "GPIO 模拟模式"
+
+config PKG_IC74HC165_MODE_SPI
+    bool "SPI 硬件模式"
+endchoice
+
+config PKG_IC74HC165_SAMPLE
+    bool "启用示例代码(sample/sample.c)"
+    default y
+
+config IC74HC165_NODE_COUNT
+    int "节点数量(74HC165 串联芯片数)"
+    default 1
+
+config PKG_IC74HC165_USE_CLKINH
+    bool "启用 CLK_INH(CE)引脚控制功能"
+    default y
+
+# SPI 专属配置
+if PKG_IC74HC165_MODE_SPI
+
+config PKG_IC74HC165_SPI_BUS_NAME
+    string "SPI 总线名称"
+    default "spi1"
+    help
+      SPI 总线名,例如 spi1、spi2,必须在系统中存在
+
+config PKG_IC74HC165_SPI_DEV_NAME
+    string "SPI 设备名称"
+    default "spi10"
+    help
+      SPI 设备逻辑名称,推荐使用 spi1x 结构
+
+endif  # PKG_IC74HC165_MODE_SPI
+
+choice
+    prompt "版本选择"
+    help
+        选择使用的 ic74hc165 软件包版本
+
+    config PKG_USING_IC74HC165_LATEST
+        bool "latest version (main branch)"
+endchoice
+
+config PKG_IC74HC165_VER
+    string
+    default "latest" if PKG_USING_IC74HC165_LATEST
+
+config PKG_IC74HC165_PATH
+    string
+    default "/packages/peripherals/ic74hc165"
+
+endif  # PKG_USING_IC74HC165

--- a/peripherals/ic74hc165/package.json
+++ b/peripherals/ic74hc165/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ic74hc165",
+  "description": "74HC165 GPIO/SPI driver for RT-Thread 4.x",
+  "description_zh": "用于RT-Thread 的74HC165串行输入并行输出芯片驱动,支持GPIO与SPI两种模式",
+  "enable": "PKG_USING_IC74HC165",
+  "keywords": [
+    "74hc165",
+    "gpio",
+    "spi",
+    "shift-register"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "godmial",
+    "email": "2633967641@qq.com",
+    "github": "godmial"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/godmial/ic74hc165.git",
+  "icon": "https://raw.githubusercontent.com/godmial/sean_ws2812b/main/icon.png",
+  "homepage": "https://github.com/godmial/ic74hc165#readme",
+  "doc": "https://github.com/godmial/ic74hc165#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/godmial/ic74hc165.git",
+      "filename": "ic74hc165.zip",
+      "VER_SHA": "main"
+    }
+  ]
+}


### PR DESCRIPTION
# 新增软件包 ic74hc165

本 PR 提交了 ic74hc165 软件包，用于驱动并行输入串行输出芯片 74HC165，支持：

- GPIO 或 SPI 模式（通过 Kconfig 二选一）
- 多片级联读取
- 可选 CLK_INH 引脚控制
- 示例线程代码（可选启用）

软件包已在以下平台实测通过 GPIO/SPI 模式运行：

- STM32F103RCT6（RT-Thread 4.1.0 / 5.1.0）
- STM32L431RCT6（RT-Thread 4.1.0 / 5.1.0）

感谢审核！
