### PR TITLE
[add] Thread-Metric性能测试

### DIFF
--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -49,4 +49,5 @@ source "$PKGS_DIR/packages/tools/RT_Trace/Kconfig"
 source "$PKGS_DIR/packages/tools/zdebug/Kconfig"
 source "$PKGS_DIR/packages/tools/RVBacktrace/Kconfig"
 source "$PKGS_DIR/packages/tools/hpatchlite-wrapper/Kconfig"
+source "$PKGS_DIR/packages/tools/thread-metric/Kconfig"
 endmenu

--- a/tools/thread-metric/Kconfig
+++ b/tools/thread-metric/Kconfig
@@ -1,0 +1,31 @@
+
+# Kconfig file for package thread-metric
+menuconfig PKG_USING_THREAD_METRIC
+    bool "Thread metrics adapted to RT-Thread."
+    default n
+
+if PKG_USING_THREAD_METRIC
+
+    config PKG_THREAD_METRIC_PATH
+        string
+        default "/packages/tools/thread-metric"
+
+    choice
+        prompt "Version"
+        help
+            Select the package version
+
+        config PKG_USING_THREAD_METRIC_V100
+            bool "v1.0.0"
+
+        config PKG_USING_THREAD_METRIC_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_THREAD_METRIC_VER
+       string
+       default "v1.0.0"    if PKG_USING_THREAD_METRIC_V100
+       default "latest"    if PKG_USING_THREAD_METRIC_LATEST_VERSION
+
+endif
+

--- a/tools/thread-metric/package.json
+++ b/tools/thread-metric/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "thread-metric",
+  "description": "Thread metric adapted to RT-Thread.",
+  "description_zh": "RT-Thread适配的Thread metric组件，用于OS性能测试与辅助优化。",
+  "enable": "PKG_USING_THREAD_METRIC",
+  "keywords": [
+    "thread-metric"
+  ],
+  "category": "tools",
+  "author": {
+    "name": "Yaochenger",
+    "email": "1516081466@qq.com",
+    "github": "Yaochenger"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/Yaochenger/Thread-Metric",
+  "icon": "unknown",
+  "homepage": "https://github.com/Yaochenger/Thread-Metric#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://github.com/Yaochenger/Thread-Metric/archive/refs/tags/1.0.0.zip",
+      "filename": "thread-metric-1.0.0.zip"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/Yaochenger/Thread-Metric.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
Thread-Metric组件用于RTOS性能测试

软件包移植于 https://github.com/eclipse-threadx/threadx/tree/master/utility/benchmarks/thread_metric