### PR TITLE
[peripherals/sensors/bmi088] 修复PKG_BMI088_USING_SAMPLE宏缺失

### DIFF
--- a/peripherals/sensors/bmi088/Kconfig
+++ b/peripherals/sensors/bmi088/Kconfig
@@ -13,6 +13,10 @@ if PKG_USING_BMI088
         bool "Enable sensor_v1 divce framework"
         select RT_USING_SENSOR
         default n
+        
+    config PKG_BMI088_USING_SAMPLE
+        bool "Enable bmi088 sample"
+        default n
 
     choice
         prompt "Version"


### PR DESCRIPTION
修复PKG_BMI088_USING_SAMPLE宏缺失导致bmi088/samples/bmi088_sample.c未加入构建的问题