### PR TITLE
ADS1146软件包索引

### DIFF
--- a/peripherals/ADS1146/Kconfig
+++ b/peripherals/ADS1146/Kconfig
@@ -1,0 +1,31 @@
+
+# Kconfig file for package ADS1146
+menuconfig PKG_USING_ADS1146
+    bool "Please add description of ADS1146 in English."
+    default n
+
+if PKG_USING_ADS1146
+
+    config PKG_ADS1146_PATH
+        string
+        default "/packages/peripherals/ADS1146"
+
+    choice
+        prompt "Version"
+        help
+            Select the package version
+
+        config PKG_USING_ADS1146_V25924
+            bool "v25.9.24"
+
+        config PKG_USING_ADS1146_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_ADS1146_VER
+       string
+       default "v25.9.24"    if PKG_USING_ADS1146_V25924
+       default "latest"    if PKG_USING_ADS1146_LATEST_VERSION
+
+endif
+

--- a/peripherals/ADS1146/package.json
+++ b/peripherals/ADS1146/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "ADS1146",
+  "description": "Please add description of ADS1146 in English.",
+  "description_zh": "这是一个关于ADS1146的驱动文件",
+  "enable": "PKG_USING_ADS1146",
+  "keywords": [
+    "ADS1146"
+  ],
+  "category": "peripherals",
+  "author": {
+    "name": "232398825",
+    "email": "hekang200112@163.com",
+    "github": "232398825"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/Pai-schoolmate/RTthread_package/tree/main/ADS1146",
+  "icon": "unknown",
+  "homepage": "https://github.com/Pai-schoolmate/RTthread_package/tree/main/ADS1146#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v25.9.24",
+      "URL": "https://ADS1146-25.9.24.zip",
+      "filename": "ADS1146-25.9.24.zip"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/Pai-schoolmate/RTthread_package/tree/main/ADS1146.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
这是基于自行编写的代码，创建的Kcongif文件和package.json文件，该软件包已经在本地使用STM32F103C8T6芯片板子验证过，能够完美的驱动Ti的芯片ADS1146