### PR TITLE
fix(can_uds): 修复ISO14229配置默认值语法错误

### DIFF
--- a/peripherals/can_uds/Kconfig
+++ b/peripherals/can_uds/Kconfig
@@ -379,7 +379,7 @@ if PKG_USING_CAN_UDS
 
     config PKG_USING_ISO14229
         bool
-        default "true"
+        default y
 
     config PKG_CAN_UDS_PATH
         string


### PR DESCRIPTION
将Kconfig中PKG_USING_ISO14229的默认值从字符串"true"改为布尔值y，
以符合Kconfig语法规范。