### PR TITLE
新增一个通用字典模块，支持任意数据类型的键值对存取，为嵌入式系统专门优化

### DIFF
--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -2,6 +2,7 @@ menu "tools packages"
 
 source "$PKGS_DIR/packages/tools/vector/Kconfig"
 source "$PKGS_DIR/packages/tools/sorch/Kconfig"
+source "$PKGS_DIR/packages/tools/dict/Kconfig"
 source "$PKGS_DIR/packages/tools/CmBacktrace/Kconfig"
 source "$PKGS_DIR/packages/tools/MCoreDump/Kconfig"
 source "$PKGS_DIR/packages/tools/EasyFlash/Kconfig"

--- a/tools/dict/Kconfig
+++ b/tools/dict/Kconfig
@@ -1,0 +1,52 @@
+# Kconfig for package dict
+menuconfig PKG_USING_DICT
+    bool "dict: a general-purpose dictionary module"
+    default n
+
+if PKG_USING_DICT
+    config PKG_DICT_PATH
+        string
+        default "/packages/tools/dict"
+
+    config DICT_DEFAULT_CAPACITY
+    int "Default initial capacity"
+    default 32
+    range 8 65536
+    help
+        Set the default bucket array capacity when creating a dictionary
+        without specifying a configuration. Recommended values: 16/32/64.
+        Higher values reduce resize operations but consume more memory.
+
+
+    config DICT_LOAD_FACTOR
+    int "Load factor (x100)"
+    default 75
+    range 50 95
+    help
+        Set the resize threshold as a percentage of capacity.
+        When element count >= capacity * (load_factor/100), the dictionary
+        automatically expands to prevent excessive hash collisions.
+
+        Common values:
+        - 50: Lower memory usage, more resize operations
+        - 75: Balanced (default)
+        - 90: Higher memory usage, fewer resize operations
+
+    choice
+        prompt "Version"
+        default PKG_USING_DICT_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_DICT_LATEST_VERSION
+            bool "latest"
+
+    endchoice
+
+    config PKG_DICT_VER
+       string
+       default "latest"    if PKG_USING_DICT_LATEST_VERSION
+
+endif
+
+

--- a/tools/dict/Kconfig
+++ b/tools/dict/Kconfig
@@ -18,7 +18,7 @@ if PKG_USING_DICT
         Higher values reduce resize operations but consume more memory.
 
 
-    config DICT_LOAD_FACTOR
+    config DICT_LOAD_FACTOR_X100
     int "Load factor (x100)"
     default 75
     range 50 95

--- a/tools/dict/package.json
+++ b/tools/dict/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dict",
+  "description": "dict is a general-purpose dictionary module",
+  "description_zh": "dict 是一个为 RT-Thread 设计的通用字典模块，支持任意数据类型的键值对存取",
+  "enable": "PKG_USING_DICT",
+  "keywords": [
+    "dict", "dictionary", "key-value pairs"
+  ],
+  "category": "tools",
+  "author": {
+    "name": "zhangguofu",
+    "email": "cleancode@163.com",
+    "github": "Gary.Zhang"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/zhangguofu/dict",
+  "icon": "unknown",
+  "homepage": "https://github.com/zhangguofu/dict#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/zhangguofu/dict.git",
+      "filename": "dict.zip",
+      "VER_SHA": "main"
+    }
+  ]
+}

--- a/tools/sorch/Kconfig
+++ b/tools/sorch/Kconfig
@@ -24,3 +24,5 @@ if PKG_USING_SORCH
        default "latest"    if PKG_USING_SORCH_LATEST_VERSION
 
 endif
+
+


### PR DESCRIPTION
dict是一个通用的字典模块，专为RT-Thread设计，支持支持任意数据类型的键值对存取，选用MurmurHash3哈希算法，业界广受好评，适合嵌入式软件场景使用。