### PR TITLE
thread manager 软件包

### DIFF
--- a/system/thread_manager/Kconfig
+++ b/system/thread_manager/Kconfig
@@ -37,22 +37,8 @@ if PKG_USING_THREAD_MANAGER
           Compiles packages/thread_manager/samples/*.c (demo threads and
           cross-subscription demo between sample threads). Disable to save Flash.
 
-    choice
-        prompt "Version"
-        default PKG_USING_THREAD_MANAGER_V100
-        help
-            Select the package version
-
-        config PKG_USING_THREAD_MANAGER_V100
-            bool "v1.0.0"
-
-        config PKG_USING_THREAD_MANAGER_LATEST_VERSION
-            bool "latest"
-    endchoice
-
     config PKG_THREAD_MANAGER_VER
        string
-       default "v1.0.0"    if PKG_USING_THREAD_MANAGER_V100
-       default "latest"    if PKG_USING_THREAD_MANAGER_LATEST_VERSION
+       default "latest"
 
 endif

--- a/system/thread_manager/Kconfig
+++ b/system/thread_manager/Kconfig
@@ -1,0 +1,58 @@
+
+# Kconfig file for package thread_manager
+menuconfig PKG_USING_THREAD_MANAGER
+    bool "Thread manager (task registry, message dispatch, manager thread)"
+    default n
+    select PKG_USING_EVENT_LOOP
+    select RT_USING_SEMAPHORE
+    select RT_USING_MUTEX
+    select RT_USING_EVENT
+    select RT_USING_MAILBOX
+    help
+        Core threading framework for RT-Thread: thread_msg_registry, TASK_ID
+        lookup, manager thread / thread_spawn_all_registered, and related APIs.
+        Thread IDs, stack sizes and priorities are defined in inc/thread_config.h
+        (edit that file for your application).
+        Delayed events (thread_evt_send_delayed_*) use packages/event_loop.
+
+if PKG_USING_THREAD_MANAGER
+
+    config PKG_THREAD_MANAGER_PATH
+        string
+        default "/packages/system/thread_manager"
+
+    config THREAD_SYSTEM_READY
+        bool "Publish system-ready event after startup sync"
+        default y
+        help
+          After all registered tasks complete thread_mgr_sys_start_sync_end,
+          the manager publishes a global rt_event bit. Tasks call
+          thread_sysready_wait() to block until the system is fully up.
+          The event bit is never cleared so late callers return immediately.
+
+    config THREAD_MANAGER_USING_SAMPLES
+        bool "Build samples (thread_test / thread_test1 / thread_test2)"
+        default y
+        help
+          Compiles packages/thread_manager/samples/*.c (demo threads and
+          cross-subscription demo between sample threads). Disable to save Flash.
+
+    choice
+        prompt "Version"
+        default PKG_USING_THREAD_MANAGER_V100
+        help
+            Select the package version
+
+        config PKG_USING_THREAD_MANAGER_V100
+            bool "v1.0.0"
+
+        config PKG_USING_THREAD_MANAGER_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_THREAD_MANAGER_VER
+       string
+       default "v1.0.0"    if PKG_USING_THREAD_MANAGER_V100
+       default "latest"    if PKG_USING_THREAD_MANAGER_LATEST_VERSION
+
+endif

--- a/system/thread_manager/package.json
+++ b/system/thread_manager/package.json
@@ -5,7 +5,7 @@
   "enable": "PKG_USING_THREAD_MANAGER",
   "keywords": [
     "thread",
-    "manager",
+    "manager"
   ],
   "category": "system",
   "author": {
@@ -19,11 +19,6 @@
   "homepage": "https://github.com/Bluetooth-BLE/thread_manager#readme",
   "doc": "unknown",
   "site": [
-    {
-      "version": "v1.0.0",
-      "URL": "https://thread_manager-1.0.0.zip",
-      "filename": "thread_manager-1.0.0.zip"
-    },
     {
       "version": "latest",
       "URL": "https://github.com/Bluetooth-BLE/thread_manager.git",

--- a/system/thread_manager/package.json
+++ b/system/thread_manager/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "thread_manager",
+  "description": "RT-Thread thread manager: task registry, message dispatch, manager thread, optional system-ready sync",
+  "description_zh": "RT-Thread 线程管理器：任务注册表、消息分发、管理线程、可选的系统就绪同步",
+  "enable": "PKG_USING_THREAD_MANAGER",
+  "keywords": [
+    "thread",
+    "manager",
+  ],
+  "category": "system",
+  "author": {
+    "name": "John.liu",
+    "email": "450547566@qq.com",
+    "github": "https://github.com/Bluetooth-BLE"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/Bluetooth-BLE/thread_manager",
+  "icon": "unknown",
+  "homepage": "https://github.com/Bluetooth-BLE/thread_manager#readme",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "v1.0.0",
+      "URL": "https://thread_manager-1.0.0.zip",
+      "filename": "thread_manager-1.0.0.zip"
+    },
+    {
+      "version": "latest",
+      "URL": "https://github.com/Bluetooth-BLE/thread_manager.git",
+      "filename": "",
+      "VER_SHA": "main"
+    }
+  ]
+}


### PR DESCRIPTION
Thread Manager 是面向 RT-Thread 的软件包，用于协调多个应用线程：管理线程负责启动/退出同步；每个任务拥有私有 mailbox（邮箱） 及可选的 内存池 承载消息；链接期消息注册表按三元组 (subscriber_task_id, publisher_task_id, msg_id) 路由回调。支持交叉订阅：当发布者任务分发自己发出的消息时，框架可将副本转发给其他订阅者，并保留消息头中的 head.publisher_task。