### PR TITLE
[feat] add ext rtc ds1307

### DIFF
--- a/peripherals/rtc/Kconfig
+++ b/peripherals/rtc/Kconfig
@@ -7,5 +7,6 @@ menuconfig PKG_USING_EXTERN_RTC_DRIVERS
 
         source "$PKGS_DIR/packages/peripherals/rtc/ds3231/Kconfig"
         source "$PKGS_DIR/packages/peripherals/rtc/rx8900/Kconfig"
+		source "$PKGS_DIR/packages/peripherals/rtc/ds1307/Kconfig"
 
     endif

--- a/peripherals/rtc/ds1307/Kconfig
+++ b/peripherals/rtc/ds1307/Kconfig
@@ -1,0 +1,48 @@
+
+# Kconfig file for package ds1307
+menuconfig PKG_USING_DS1307
+    bool "ds1307 Extern RTC Driver."
+    default n
+	select RT_USING_MTD_NOR
+	select RT_USING_I2C
+
+if PKG_USING_DS1307
+
+	config PKG_DS1307_IIC_BUS
+		string "select iic bus"
+		default "i2c1"
+
+	config PKG_DS1307_DEBUG
+		bool "Enable  output rtc ds1307 debug message"
+		default n
+		
+	config PKG_DS1307_RAM_SHELL_TEST
+		bool "Enable   ds1307  RAM read write test in finsh"
+		default n
+	
+    config PKG_DS1307_PATH
+        string
+        default "/packages/peripherals/rtc/ds1307"
+
+    choice
+		default PKG_USING_DS1307_LATEST_VERSION
+        prompt "Version"
+        help
+            Select the package version
+
+        config PKG_USING_DS1307_V100
+            bool "v1.0.0"
+
+        config PKG_USING_DS1307_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_DS1307_VER
+		string
+		default "v1.0.0"    if PKG_USING_DS1307_V100
+		default "latest"    if PKG_USING_DS1307_LATEST_VERSION
+	   
+
+
+endif
+

--- a/peripherals/rtc/ds1307/package.json
+++ b/peripherals/rtc/ds1307/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "ds1307",
+  "description": "Extern RTC driver for ds1307 .",
+  "description_zh": " ds1307  外置RTC驱动",
+  "enable": "PKG_USING_DS1307",
+  "keywords": [
+    "ds1307"
+  ],
+  "category": "peripherals/rtc",
+  "author": {
+    "name": "chejia12",
+    "email": "1085582540@qq.com",
+    "github": "chejia12"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://gitee.com/chejia12/ds1307",
+  "icon": "unknown",
+  "homepage": "https://gitee.com/chejia12/ds1307",
+  "doc": "unknown",
+  "site": [
+    {
+      "version": "V1.0.0",
+      "URL": "https://gitee.com/chejia12/ds1307/releases/download/V1.0.0/V1.0.0.zip",
+      "filename": "ds1307V1.0.0.zip"
+    },
+    {
+      "version": "latest",
+      "URL": "https://gitee.com/chejia12/ds1307.git",
+      "filename": "",
+      "VER_SHA": "master"
+    }
+  ]
+}


### PR DESCRIPTION
- 新增了DS1307 实时时钟驱动和56 字节的 NV SRAM（非易失性静态随机存取存储器）功能。
- 软件包已经在N32平台测试通过，测试了包的拉取，包的不同版本拉取使用，驱动也做了测试，功能正常