### PR TITLE
[components][fee]

### DIFF
--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -57,4 +57,5 @@ source "$PKGS_DIR/packages/tools/thread-metric/Kconfig"
 source "$PKGS_DIR/packages/tools/uORB/Kconfig"
 source "$PKGS_DIR/packages/tools/RT-Tunnel/Kconfig"
 source "$PKGS_DIR/packages/tools/Virtual-Terminal/Kconfig"
+source "$PKGS_DIR/packages/tools/fee/Kconfig"
 endmenu

--- a/tools/fee/Kconfig
+++ b/tools/fee/Kconfig
@@ -1,0 +1,40 @@
+# Kconfig file for package fee
+menuconfig PKG_USING_FEE
+    bool "fee: fixed-block Flash EEPROM emulation package"
+    default n
+
+if PKG_USING_FEE
+
+    config PKG_FEE_PATH
+        string
+        default "/packages/tools/fee"
+
+    config FEE_MOCK_FLASH_SIZE
+        hex "RAM mock flash size"
+        default 0xA0000
+        help
+            Size of the built-in RAM-backed mock flash used by the default
+            weak flash driver implementation in port/fee_port.c.
+
+    config FEE_USING_SAMPLE
+        bool "Enable samples"
+        default n
+        depends on RT_USING_FINSH
+        help
+            Build the MSH-based smoke and diagnostic sample.
+
+    choice
+        prompt "Version"
+        default PKG_USING_FEE_LATEST_VERSION
+        help
+            Select the package version
+
+        config PKG_USING_FEE_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_FEE_VER
+       string
+       default "latest" if PKG_USING_FEE_LATEST_VERSION
+
+endif

--- a/tools/fee/Kconfig
+++ b/tools/fee/Kconfig
@@ -25,9 +25,12 @@ if PKG_USING_FEE
 
     choice
         prompt "Version"
-        default PKG_USING_FEE_LATEST_VERSION
+        default PKG_USING_FEE_V0_1_0
         help
             Select the package version
+
+        config PKG_USING_FEE_V0_1_0
+            bool "v0.1.0"
 
         config PKG_USING_FEE_LATEST_VERSION
             bool "latest"
@@ -35,6 +38,7 @@ if PKG_USING_FEE
 
     config PKG_FEE_VER
        string
+       default "v0.1.0" if PKG_USING_FEE_V0_1_0
        default "latest" if PKG_USING_FEE_LATEST_VERSION
 
 endif

--- a/tools/fee/package.json
+++ b/tools/fee/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "fee",
+  "description": "Fixed-block Flash EEPROM emulation component for RT-Thread",
+  "description_zh": "面向 RT-Thread 的固定逻辑块 Flash EEPROM Emulation 软件包",
+  "enable": "PKG_USING_FEE",
+  "keywords": [
+    "flash",
+    "fee",
+    "eeprom emulation",
+    "storage",
+    "rt-thread"
+  ],
+  "category": "tools",
+  "author": {
+    "name": "O-O-BOOK",
+    "email": "127711564+O-O-BOOK@users.noreply.github.com",
+    "github": "O-O-BOOK"
+  },
+  "license": "Apache-2.0",
+  "repository": "https://github.com/O-O-BOOK/fee",
+  "icon": "unknown",
+  "homepage": "https://github.com/O-O-BOOK/fee#readme",
+  "doc": "https://github.com/O-O-BOOK/fee/tree/main/docs",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/O-O-BOOK/fee.git",
+      "filename": "Null for git package",
+      "VER_SHA": "main"
+    }
+  ]
+}

--- a/tools/fee/package.json
+++ b/tools/fee/package.json
@@ -23,6 +23,12 @@
   "doc": "https://github.com/O-O-BOOK/fee/tree/main/docs",
   "site": [
     {
+      "version": "v0.1.0",
+      "URL": "https://github.com/O-O-BOOK/fee.git",
+      "filename": "Null for git package",
+      "VER_SHA": "v0.1.0"
+    },
+    {
       "version": "latest",
       "URL": "https://github.com/O-O-BOOK/fee.git",
       "filename": "Null for git package",


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

为什么提交这份PR (why to submit this PR)
本 PR 引入并完善了一个新的独立组件 fee。它面向嵌入式场景下“少量 block 化数据需要可靠持久化到 flash”的需求，用来承接配置参数、标定数据、状态快照等非易失数据，而不是让业务层直接处理裸 flash record、掉电恢复、GC 和版本回滚。

从设计目标上看，这个组件并不是要替代通用 KV 数据库，而是要解决固定逻辑块持久化场景下，通用方案常见的两个痛点：

相对 FlashDB KVDB 一类通用 KV 机制，降低 GC 被动触发、整 sector 扫描、逐条物理记录搬运带来的长尾问题
相对“上电后全盘扫描历史记录再建立索引”的恢复方式，降低 block 首次可读时间，尤其是关键 block 的启动读取时延
这个组件主要解决以下问题：

业务层不再需要自己维护“参数写 flash”的散落逻辑，避免每个项目都重复实现一套简化版 EEPROM Emulation
将 block 管理、版本覆盖、失效、回滚、完整性校验、启动恢复、GC 等通用能力收敛为可复用组件，而不是和某个板级 FLS 驱动强耦合
在数据量和历史 record 增长后，避免每次读都全盘扫描 flash，降低读取和恢复路径的不确定性
在系统上电启动时，不必等待全量 flash 扫描完成，关键 block 可以更早恢复可读
为后续接入真实 flash/FLS 驱动提供统一接口，同时保留 QEMU/RAM mock 环境下可验证、可诊断的 bring-up 能力
如果目标问题是“FlashDB 在固定 block 存储场景下 GC 偏慢、上电读 block 偏慢”，那么这套 fee 的设计方向就是针对这两个问题给出专用解法，而不是继续在通用 KV 模型上做局部修补。

## fee 当前的核心机制如下：

追加写日志结构：block 新版本不是原地改写，而是以 record 形式追加写入 flash，通过 record header、commit tail 和 CRC 保证格式完整性与数据有效性
RAM cache 快速索引：运行期使用 RAM cache 维护每个 block 的 cur/prev 地址和状态，读路径先查 cache，再按地址读 payload，避免反复全盘扫描
双副本与回滚：每个 block 可保留当前版本和上一版本，既支持显式 rollback，也在当前副本异常时保留降级读取机会
checkpoint + tail scan 快速启动：启动时先恢复 checkpoint，把可确认的 block 映射装回 cache；boot-critical block 可在 CKPT_READY 阶段提前可读，剩余 tail 再后台补扫到 FULL_READY
lane 分级存储：按 block 特性拆分 FAST / NORMAL / BULK lane，把高频小数据和低频大数据隔离，减少相互干扰
同步读 + 异步写调度：read 走同步路径，write/invalidate/rollback 走调度队列并由 fee_mainfunction() 推进，兼顾读延迟确定性和后台擦写调度
后台 checkpoint 与 GC：当 lane 空间或脏数据达到阈值时，组件自动请求 checkpoint 和 GC，以小步后台推进方式控制维护成本
统一驱动抽象：fee 核心只依赖 fee_flash_driver_* 接口，上层逻辑不关心底层接的是 RAM mock、QEMU 还是实际 flash/FLS 驱动
因此，这个 PR 不只是“加几个测试”或“适配一个 BSP”，而是把 fee 作为一个可独立接入、可独立验证、可继续迁移到真实硬件的 FEE 组件完整落地出来。

你的解决方案是什么 (what is your solution)
将 components/fee 文档整理到 components/fee/doc/，补充 README、对外 API、on-flash 格式、checkpoint/cache、启动恢复、调度/GC、配置规则、端口适配和诊断测试说明
引入统一的 fee_flash_driver_* 驱动抽象；fee_port.c 仅保留薄封装，默认提供 weak 的 RAM mock backend，板级工程可通过 strong definition 覆盖为真实 flash/FLS 驱动
避免 fee 核心逻辑感知底层介质类型
在 bsp/qemu-vexpress-a9 打开 fee 组件，使用 RAM mock flash 完成 bring-up 和回归验证
增强 fee_test.c，补充 fee_test / fee_diag_test 场景，覆盖 block 写入、读回、rollback、invalidate、重新初始化恢复
在诊断测试中增加每次 block 操作的耗时统计、GC 耗时统计，以及底层驱动 read/write/erase/poll 的真实访问次数与字节数统计
在诊断测试中增加 mock flash 中 checkpoint、lane、sector、record 的实际布局打印和 raw dump，方便定位 on-flash 数据格式问题
保持上层使用方式稳定，业务侧仍通过 fee_api.h 使用 FEE；后续迁移到真实硬件时，仅需按统一接口实现 fee_flash_driver_*
请提供验证的bsp和config (provide the config and bsp)
BSP: bsp/qemu-vexpress-a9

CONFIG_PKG_USING_FEE=y
CONFIG_PKG_FEE_PATH="/packages/tools/fee"
CONFIG_FEE_MOCK_FLASH_SIZE=0xA0000
CONFIG_FEE_USING_SAMPLE=y

本地验证: scons -j8 编译通过
本地验证: 在 QEMU shell 中执行 fee_test
本地验证: 在 QEMU shell 中执行 fee_diag_test
本地验证: 覆盖 block 读写、rollback、invalidate、re-init recovery、fast lane GC、checkpoint/sector/record 布局打印、底层驱动访问计数统计
action: N/A（本次为本地 QEMU 验证，未提供个人 fork action 链接）
]

```
 \ | /
- RT -     Thread Operating System
 / | \     5.3.0 build May  8 2026 11:26:54
 2006 - 2024 Copyright by RT-Thread team
[I/SDIO] SD card capacity 65536 KB.
[I/SDIO] SD card switch to High Speed / SDR25 mode
[I/FileSystem] file system initialization done!

Hello RT-Thread!
msh />
msh />
msh />
msh />
msh />
msh />
msh />
msh />
msh />
msh />fee_test
fee_test: start
fee_test: PASS
msh />
msh />
```

```
 \ | /
- RT -     Thread Operating System
 / | \     5.3.0 build May  8 2026 11:26:54
 2006 - 2024 Copyright by RT-Thread team
[I/SDIO] SD card capacity 65536 KB.
[I/SDIO] SD card switch to High Speed / SDR25 mode
[I/FileSystem] file system initialization done!

Hello RT-Thread!
msh />
msh />
msh />
msh />
msh />
msh />
msh />
msh />
msh />
msh />fee_diag_test
fee_diag_test: start
fee_diag_test: init time=10 ms ticks=1 wait_loops=0 driver[init=1 read=13/2864B write=3/192B erase=8/458752B poll=0]
fee_diag_test: write block1 fast_a time=0 ms ticks=0 wait_loops=1 driver[init=0 read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: write block1 fast_a len=32
fee_diag_test:   0000: 11 14 17 1a 1d 20 23 26 29 2c 2f 32 35 38 3b 3e
fee_diag_test:   0016: 41 44 47 4a 4d 50 53 56 59 5c 5f 62 65 68 6b 6e
fee_diag_test: read block1 fast_a time=0 ms ticks=0 wait_loops=0 driver[init=0 read=3/80B write=0/0B erase=0/0B poll=0]
fee_diag_test: read block1 fast_a len=32
fee_diag_test:   0000: 11 14 17 1a 1d 20 23 26 29 2c 2f 32 35 38 3b 3e
fee_diag_test:   0016: 41 44 47 4a 4d 50 53 56 59 5c 5f 62 65 68 6b 6e
fee_diag_test: write block1 fast_b time=0 ms ticks=0 wait_loops=1 driver[init=0 read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: write block1 fast_b len=32
fee_diag_test:   0000: 51 54 57 5a 5d 60 63 66 69 6c 6f 72 75 78 7b 7e
fee_diag_test:   0016: 81 84 87 8a 8d 90 93 96 99 9c 9f a2 a5 a8 ab ae
fee_diag_test: read block1 fast_b time=0 ms ticks=0 wait_loops=0 driver[init=0 read=3/80B write=0/0B erase=0/0B poll=0]
fee_diag_test: read block1 fast_b len=32
fee_diag_test:   0000: 51 54 57 5a 5d 60 63 66 69 6c 6f 72 75 78 7b 7e
fee_diag_test:   0016: 81 84 87 8a 8d 90 93 96 99 9c 9f a2 a5 a8 ab ae
fee_diag_test: rollback block1 time=0 ms ticks=0 wait_loops=1 driver[init=0 read=4/112B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: read block1 rollback time=0 ms ticks=0 wait_loops=0 driver[init=0 read=3/80B write=0/0B erase=0/0B poll=0]
fee_diag_test: read block1 rollback len=32
fee_diag_test:   0000: 11 14 17 1a 1d 20 23 26 29 2c 2f 32 35 38 3b 3e
fee_diag_test:   0016: 41 44 47 4a 4d 50 53 56 59 5c 5f 62 65 68 6b 6e
fee_diag_test: write block2 normal_a time=0 ms ticks=0 wait_loops=1 driver[init=0 read=0/0B write=4/1240B erase=1/57344B poll=1]
fee_diag_test: write block2 normal_a len=64
fee_diag_test:   0000: 21 24 27 2a 2d 30 33 36 39 3c 3f 42 45 48 4b 4e
fee_diag_test:   0016: 51 54 57 5a 5d 60 63 66 69 6c 6f 72 75 78 7b 7e
fee_diag_test:   0032: 81 84 87 8a 8d 90 93 96 99 9c 9f a2 a5 a8 ab ae
fee_diag_test:   0048: b1 b4 b7 ba bd c0 c3 c6 c9 cc cf d2 d5 d8 db de
fee_diag_test: read block2 normal_a time=0 ms ticks=0 wait_loops=0 driver[init=0 read=3/112B write=0/0B erase=0/0B poll=0]
fee_diag_test: read block2 normal_a len=64
fee_diag_test:   0000: 21 24 27 2a 2d 30 33 36 39 3c 3f 42 45 48 4b 4e
fee_diag_test:   0016: 51 54 57 5a 5d 60 63 66 69 6c 6f 72 75 78 7b 7e
fee_diag_test:   0032: 81 84 87 8a 8d 90 93 96 99 9c 9f a2 a5 a8 ab ae
fee_diag_test:   0048: b1 b4 b7 ba bd c0 c3 c6 c9 cc cf d2 d5 d8 db de
fee_diag_test: re-init time=0 ms ticks=0 wait_loops=4 driver[init=1 read=13/2864B write=0/0B erase=0/0B poll=4]

fee_diag_test: read block1 after re-init time=0 ms ticks=0 wait_loops=0 driver[init=0 read=3/80B write=0/0B erase=0/0B poll=0]
fee_diag_test: read block1 after re-init len=32
fee_diag_test:   0000: 11 14 17 1a 1d 20 23 26 29 2c 2f 32 35 38 3b 3e
fee_diag_test:   0016: 41 44 47 4a 4d 50 53 56 59 5c 5f 62 65 68 6b 6e
fee_diag_test: read block2 after re-init time=0 ms ticks=0 wait_loops=0 driver[init=0 read=3/112B write=0/0B erase=0/0B poll=0]
fee_diag_test: read block2 after re-init len=64
fee_diag_test:   0000: 21 24 27 2a 2d 30 33 36 39 3c 3f 42 45 48 4b 4e
fee_diag_test:   0016: 51 54 57 5a 5d 60 63 66 69 6c 6f 72 75 78 7b 7e
fee_diag_test:   0032: 81 84 87 8a 8d 90 93 96 99 9c 9f a2 a5 a8 ab ae
fee_diag_test:   0048: b1 b4 b7 ba bd c0 c3 c6 c9 cc cf d2 d5 d8 db de
fee_diag_test: gc_write[000] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001c640->0x0001c840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[001] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001c840->0x0001ca40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[002] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001ca40->0x0001cc40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[003] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001cc40->0x0001ce40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[004] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001ce40->0x0001d040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[005] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001d040->0x0001d240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[006] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001d240->0x0001d440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[007] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001d440->0x0001d640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[008] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001d640->0x0001d840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[009] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001d840->0x0001da40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[010] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001da40->0x0001dc40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[011] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001dc40->0x0001de40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[012] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001de40->0x0001e040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[013] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001e040->0x0001e240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[014] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001e240->0x0001e440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[015] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001e440->0x0001e640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[016] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001e640->0x0001e840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[017] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001e840->0x0001ea40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[018] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001ea40->0x0001ec40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[019] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001ec40->0x0001ee40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[020] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001ee40->0x0001f040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[021] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001f040->0x0001f240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[022] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001f240->0x0001f440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[023] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001f440->0x0001f640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[024] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001f640->0x0001f840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[025] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001f840->0x0001fa40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[026] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001fa40->0x0001fc40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[027] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001fc40->0x0001fe40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[028] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x0001fe40->0x00020040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[029] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00020040->0x00020240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[030] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00020240->0x00020440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[031] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00020440->0x00020640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[032] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00020640->0x00020840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[033] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00020840->0x00020a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[034] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00020a40->0x00020c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[035] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00020c40->0x00020e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[036] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00020e40->0x00021040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[037] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00021040->0x00021240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[038] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00021240->0x00021440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[039] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00021440->0x00021640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[040] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00021640->0x00021840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[041] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00021840->0x00021a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[042] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00021a40->0x00021c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[043] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00021c40->0x00021e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[044] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00021e40->0x00022040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[045] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00022040->0x00022240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[046] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00022240->0x00022440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[047] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00022440->0x00022640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[048] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00022640->0x00022840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[049] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00022840->0x00022a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[050] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00022a40->0x00022c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[051] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00022c40->0x00022e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[052] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00022e40->0x00023040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[053] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00023040->0x00023240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[054] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00023240->0x00023440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[055] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00023440->0x00023640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[056] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00023640->0x00023840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[057] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00023840->0x00023a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[058] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00023a40->0x00023c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[059] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00023c40->0x00023e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[060] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00023e40->0x00024040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[061] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00024040->0x00024240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[062] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00024240->0x00024440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[063] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00024440->0x00024640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[064] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00024640->0x00024840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[065] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00024840->0x00024a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[066] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00024a40->0x00024c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[067] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00024c40->0x00024e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[068] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00024e40->0x00025040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[069] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00025040->0x00025240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[070] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00025240->0x00025440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[071] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00025440->0x00025640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[072] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00025640->0x00025840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[073] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00025840->0x00025a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[074] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00025a40->0x00025c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[075] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00025c40->0x00025e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[076] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00025e40->0x00026040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[077] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00026040->0x00026240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[078] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00026240->0x00026440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[079] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00026440->0x00026640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[080] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00026640->0x00026840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[081] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00026840->0x00026a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[082] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00026a40->0x00026c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[083] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00026c40->0x00026e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[084] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00026e40->0x00027040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[085] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00027040->0x00027240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[086] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00027240->0x00027440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[087] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00027440->0x00027640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[088] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00027640->0x00027840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[089] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00027840->0x00027a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[090] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00027a40->0x00027c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[091] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00027c40->0x00027e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[092] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00027e40->0x00028040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[093] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00028040->0x00028240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[094] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00028240->0x00028440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[095] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00028440->0x00028640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[096] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00028640->0x00028840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[097] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00028840->0x00028a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[098] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00028a40->0x00028c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[099] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00028c40->0x00028e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[100] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00028e40->0x00029040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[101] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00029040->0x00029240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[102] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00029240->0x00029440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[103] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00029440->0x00029640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[104] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00029640->0x00029840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[105] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=0->0 gen=1->1 free=0x00029840->0x00029a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[106] time=10 ms ticks=1 wait_loops=7 fast_lane[sector=0->2 gen=1->2 free=0x00029a40->0x00038440 gc=1] driver[read=4/1088B write=8/2360B erase=3/172032B poll=7]
fee_diag_test: gc_write[107] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00038440->0x00038640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[108] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00038640->0x00038840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[109] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00038840->0x00038a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[110] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00038a40->0x00038c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[111] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00038c40->0x00038e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[112] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00038e40->0x00039040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[113] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00039040->0x00039240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[114] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00039240->0x00039440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[115] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00039440->0x00039640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[116] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00039640->0x00039840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[117] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00039840->0x00039a40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[118] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00039a40->0x00039c40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[119] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00039c40->0x00039e40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[120] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x00039e40->0x0003a040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[121] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003a040->0x0003a240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[122] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003a240->0x0003a440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[123] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003a440->0x0003a640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[124] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003a640->0x0003a840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[125] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003a840->0x0003aa40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[126] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003aa40->0x0003ac40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[127] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003ac40->0x0003ae40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[128] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003ae40->0x0003b040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[129] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003b040->0x0003b240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[130] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003b240->0x0003b440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[131] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003b440->0x0003b640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[132] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003b640->0x0003b840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[133] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003b840->0x0003ba40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[134] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003ba40->0x0003bc40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[135] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003bc40->0x0003be40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[136] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003be40->0x0003c040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[137] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003c040->0x0003c240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[138] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003c240->0x0003c440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[139] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003c440->0x0003c640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[140] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003c640->0x0003c840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[141] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003c840->0x0003ca40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[142] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003ca40->0x0003cc40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[143] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003cc40->0x0003ce40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[144] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003ce40->0x0003d040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[145] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003d040->0x0003d240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[146] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003d240->0x0003d440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[147] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003d440->0x0003d640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[148] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003d640->0x0003d840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[149] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003d840->0x0003da40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[150] time=0 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003da40->0x0003dc40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[151] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003dc40->0x0003de40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[152] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003de40->0x0003e040 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[153] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003e040->0x0003e240 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[154] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003e240->0x0003e440 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[155] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003e440->0x0003e640 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[156] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003e640->0x0003e840 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[157] time=10 ms ticks=1 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003e840->0x0003ea40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[158] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003ea40->0x0003ec40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc_write[159] time=0 ms ticks=0 wait_loops=1 fast_lane[sector=2->2 gen=2->2 free=0x0003ec40->0x0003ee40 gc=0] driver[read=0/0B write=4/1208B erase=1/57344B poll=1]
fee_diag_test: gc summary writes=160 total_time=750 ms total_ticks=96 gc_events=1 gc_time=10 ms gc_ticks=1 gc_max_ticks=1
fee_diag_test: read block1 after gc time=0 ms ticks=0 wait_loops=0 driver[init=0 read=3/80B write=0/0B erase=0/0B poll=0]
fee_diag_test: read block1 after gc len=32
fee_diag_test:   0000: ff 02 05 08 0b 0e 11 14 17 1a 1d 20 23 26 29 2c
fee_diag_test:   0016: 2f 32 35 38 3b 3e 41 44 47 4a 4d 50 53 56 59 5c
fee_diag_test: invalidate block1 time=0 ms ticks=0 wait_loops=1 driver[init=0 read=0/0B write=3/1176B erase=1/57344B poll=1]
fee_diag_test: block1 status after invalidate=2
fee_diag_test: read invalidated block1 time=10 ms ticks=1 wait_loops=0 driver[init=0 read=0/0B write=0/0B erase=0/0B poll=0]
fee_diag_test: flash layout [final] total=0x000a0000 erase=0x0000e000 read_unit=1 program_unit=8
fee_diag_test: meta[0] base=0x00000000 valid=1 generation=165 entries=2 commit=0x434f4d4d
fee_diag_test:   meta[0] lane=fast active=2 dst=0 spare=0 gen=2 free=0x0003f040
fee_diag_test:   meta[0] lane=normal active=0 dst=1 spare=2 gen=1 free=0x000460b0
fee_diag_test:   meta[0] lane=bulk active=0 dst=1 spare=1 gen=1 free=0x00070040
fee_diag_test: meta[1] base=0x0000e000 valid=1 generation=164 entries=2 commit=0x434f4d4d
fee_diag_test:   meta[1] lane=fast active=2 dst=0 spare=0 gen=2 free=0x0003ee40
fee_diag_test:   meta[1] lane=normal active=0 dst=1 spare=2 gen=1 free=0x000460b0
fee_diag_test:   meta[1] lane=bulk active=0 dst=1 spare=1 gen=1 free=0x00070040
fee_diag_test: meta active raw addr=0x00000000 len=64
fee_diag_test:   0x00000000: 4b 43 45 46 00 01 00 00 a5 00 00 00 00 00 00 00
fee_diag_test:   0x00000010: 00 00 00 00 00 00 00 00 00 00 00 00 40 f0 03 00
fee_diag_test:   0x00000020: 02 00 00 00 02 00 00 03 00 00 00 00 b0 60 04 00
fee_diag_test:   0x00000030: 01 00 00 00 00 01 02 03 00 00 00 00 40 00 07 00
fee_diag_test: lane=fast range=[0x0001c000,0x00046000) active=2 dst=0 spare=0 old=0 free=0x0003f040 limit=0x00046000 dirty_records=0 dirty_bytes=0
fee_diag_test:   sector=0 base=0x0001c000 ERASED
fee_diag_test:   sector=1 base=0x0002a000 ERASED
fee_diag_test:   sector=2 base=0x00038000 header-valid=0 state=ACTIVE generation=2 data=[0x00038040,0x00046000)

fee_diag_test: sector raw addr=0x00038000 len=64
fee_diag_test:   0x00038000: 53 45 45 46 00 01 01 22 02 00 00 00 00 00 00 00
fee_diag_test:   0x00038010: 40 80 03 00 00 60 04 00 02 00 00 00 6a 80 24 00
fee_diag_test:   0x00038020: 4d 4d 4f 43 00 00 00 00 00 00 00 00 00 00 00 00
fee_diag_test:   0x00038030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
fee_diag_test: active sector raw addr=0x00038000 len=96
fee_diag_test:   0x00038000: 53 45 45 46 00 01 01 22 02 00 00 00 00 00 00 00
fee_diag_test:   0x00038010: 40 80 03 00 00 60 04 00 02 00 00 00 6a 80 24 00
fee_diag_test:   0x00038020: 4d 4d 4f 43 00 00 00 00 00 00 00 00 00 00 00 00
fee_diag_test:   0x00038030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
fee_diag_test:   0x00038040: 52 45 45 46 01 00 d1 01 20 00 20 00 6d 00 00 00
fee_diag_test:   0x00038050: 00 00 00 00 00 00 00 00 f6 28 ba d3 00 00 00 00
fee_diag_test: lane=normal range=[0x00046000,0x00070000) active=0 dst=1 spare=2 old=0 free=0x000460b0 limit=0x00054000 dirty_records=0 dirty_bytes=0
fee_diag_test:   sector=0 base=0x00046000 state=ACTIVE generation=1 data=[0x00046040,0x00054000)
fee_diag_test:     record=0 addr=0x00046040 block=2 type=DATA seq=1 len=64 committed=1 prev=0x00000000
fee_diag_test: record header raw addr=0x00046040 len=32
fee_diag_test:   0x00046040: 52 45 45 46 02 00 d1 01 40 00 20 00 01 00 00 00
fee_diag_test:   0x00046050: 00 00 00 00 00 00 00 00 21 f7 a5 ae 00 00 00 00
fee_diag_test: record payload raw addr=0x00046060 len=64
fee_diag_test:   0x00046060: 21 24 27 2a 2d 30 33 36 39 3c 3f 42 45 48 4b 4e
fee_diag_test:   0x00046070: 51 54 57 5a 5d 60 63 66 69 6c 6f 72 75 78 7b 7e
fee_diag_test:   0x00046080: 81 84 87 8a 8d 90 93 96 99 9c 9f a2 a5 a8 ab ae
fee_diag_test:   0x00046090: b1 b4 b7 ba bd c0 c3 c6 c9 cc cf d2 d5 d8 db de
fee_diag_test: record tail raw addr=0x000460a0 len=16
fee_diag_test:   0x000460a0: 60 44 b0 0a 3e 69 7a 2e 00 00 00 00 4d 4d 4f 43
fee_diag_test:   sector=0 stop_addr=0x000460b0 record_count=1
fee_diag_test:   sector=1 base=0x00054000 ERASED
fee_diag_test:   sector=2 base=0x00062000 ERASED
fee_diag_test: active sector raw addr=0x00046000 len=96
fee_diag_test:   0x00046000: 53 45 45 46 00 01 02 22 01 00 00 00 00 00 00 00
fee_diag_test:   0x00046010: 40 60 04 00 00 40 05 00 01 00 00 00 c9 81 00 ec
fee_diag_test:   0x00046020: 4d 4d 4f 43 00 00 00 00 00 00 00 00 00 00 00 00
fee_diag_test:   0x00046030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
fee_diag_test:   0x00046040: 52 45 45 46 02 00 d1 01 40 00 20 00 01 00 00 00
fee_diag_test:   0x00046050: 00 00 00 00 00 00 00 00 21 f7 a5 ae 00 00 00 00
fee_diag_test: lane=bulk range=[0x00070000,0x0008c000) active=0 dst=1 spare=1 old=0 free=0x00070040 limit=0x0007e000 dirty_records=0 dirty_bytes=0
fee_diag_test:   sector=0 base=0x00070000 state=ACTIVE generation=1 data=[0x00070040,0x0007e000)
fee_diag_test:   sector=0 stop_addr=0x00070040 record_count=0
fee_diag_test:   sector=1 base=0x0007e000 ERASED
fee_diag_test: active sector raw addr=0x00070000 len=64
fee_diag_test:   0x00070000: 53 45 45 46 00 01 03 22 01 00 00 00 00 00 00 00
fee_diag_test:   0x00070010: 40 00 07 00 00 e0 07 00 01 00 00 00 43 41 ee 8c
fee_diag_test:   0x00070020: 4d 4d 4f 43 00 00 00 00 00 00 00 00 00 00 00 00
fee_diag_test:   0x00070030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
fee_diag_test: PASS
msh />
msh />
```