### PR TITLE
ai: Add AIfES package

### DIFF
--- a/ai/AIfES/Kconfig
+++ b/ai/AIfES/Kconfig
@@ -1,0 +1,55 @@
+
+# Kconfig file for package AI4ES
+menuconfig PKG_USING_AIFES
+    select RT_USING_POSIX_FS
+    bool "AIfES: A machine learning framework, developed and maintained by Fraunhofer Institute for Microelectronic Circuits and Systems."
+    default n
+
+if PKG_USING_AIFES
+
+    config PKG_AIFES_PATH
+        string
+        default "/packages/ai/AIfES"
+
+    config AIFES_USING_XOR_INFERENCE_F32_EXAMPLE
+            bool "XOR inference example"
+            help
+               The sketch shows an example of how the inference of an already trained network is performed. In the concrete example, a neural network was trained to map an XOR gate. The neural network was trained in Keras and the configuration including the weights was imported into AIfES. The network structure is 2-3(Sigmoid)-1(Sigmoid) and Sigmoid is used as activation function. The calculation is done in float 32.
+            default y
+
+    config AIFES_USING_XOR_TRAINING_F32_EXAMPLE
+            bool "XOR training example"
+            help
+                The sketch shows an example of how a neural network is trained from scratch in AIfES using training data. As in the example "0_XOR_Inference", an XOR gate is mapped here using a neural network. The 4 different states of an XOR gate are fed in as training data here. The network structure is 2-3(Sigmoid)-1(Sigmoid) and Sigmoid is used as activation function. In the example, the weights are initialized randomly in a range of values from -2 to +2. The Gotrot initialization was inserted as an alternative and commented out. For the training the ADAM Optimizer is used, the SGD Optimizer was commented out. The optimizer performs a batch training over 100 epochs. The calculation is done in float 32.
+            default y
+
+    config AIFES_USING_CNN_TRAINING_F32_EXAMPLE
+            bool "CNN training example"
+            help
+                The sketch shows an example of how the training of a convolutional neural network (CNN) is performed. The training data consists of images with horizontal and vertical stripes. This example is just for demonstration of the training procedure with a CNN and has no deeper meaning.
+            default n
+
+    config AIFES_USING_MNIST_TRAINING_F32_EXAMPLE
+            bool "MNIST training example"
+            help
+                The sketch shows an example of training a convolutional neural network (CNN) on the MNIST dataset.
+            default n
+
+    choice
+        prompt "Version"
+        default PKG_USING_AIFES_LATEST_VERSION
+        help
+            Select the package version
+        config PKG_USING_AIFES_LATEST_VERSION
+            bool "latest"
+    endchoice
+
+    config PKG_AIFES_VER
+       string
+       default "latest"    if PKG_USING_AIFES_LATEST_VERSION
+
+    config PKG_LIME_TM_VER_NUM
+        hex
+        default 0x99999 if PKG_USING_AIFES_LATEST_VERSION
+
+endif

--- a/ai/AIfES/package.json
+++ b/ai/AIfES/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "AIfES",
+  "description": "AIfES machine learning framework.",
+  "description_zh": "嵌入式机器学习库 (神经网络)",
+  "enable": "PKG_USING_AIFES",
+  "keywords": [
+    "Machine Learning",
+    "Neural Network"
+  ],
+  "category": "ai",
+  "author": {
+    "name": "wuhanstudio",
+    "email": "wuhanstudios@gmail.com",
+    "github": "wuhanstudio"
+  },
+  "license": "AGPL-3.0",
+  "repository": "https://github.com/wuhanstudio/AIfES_for_Arduino",
+  "homepage": "https://github.com/wuhanstudio/AIfES_for_Arduino#readme",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/wuhanstudio/AIfES_for_Arduino.git",
+      "filename": "",
+      "VER_SHA": "main"
+    }
+  ]
+}

--- a/ai/Kconfig
+++ b/ai/Kconfig
@@ -12,5 +12,6 @@ source "$PKGS_DIR/packages/ai/naxos/Kconfig"
 source "$PKGS_DIR/packages/ai/ncnn/Kconfig"
 source "$PKGS_DIR/packages/ai/r-tinymaix/Kconfig"
 source "$PKGS_DIR/packages/ai/llmchat/Kconfig"
+source "$PKGS_DIR/packages/ai/AIfES/Kconfig"
 
 endmenu


### PR DESCRIPTION
AIfES: Fraunhofer Institute 提供的机器学习框架

https://github.com/Fraunhofer-IMS/AIfES_for_Arduino

类似于 TensorFlow Lite Micro，AIfES 支持在 MCU 上训练、推理机器学习模型，但是这个框架的模型训练，需要把整个训练集加载到 SRAM，所以实际上能用的只有推理，训练只支持非常小的数据集 (XOR，Iris)。
