### PR TITLE
[add] MRamTrace: lightweight RAM-backed function tracing for MCU firmware

### DIFF
--- a/tools/Kconfig
+++ b/tools/Kconfig
@@ -58,4 +58,5 @@ source "$PKGS_DIR/packages/tools/uORB/Kconfig"
 source "$PKGS_DIR/packages/tools/RT-Tunnel/Kconfig"
 source "$PKGS_DIR/packages/tools/Virtual-Terminal/Kconfig"
 source "$PKGS_DIR/packages/tools/fee/Kconfig"
+source "$PKGS_DIR/packages/tools/MRamTrace/Kconfig"
 endmenu

--- a/tools/MRamTrace/Kconfig
+++ b/tools/MRamTrace/Kconfig
@@ -1,0 +1,30 @@
+menuconfig PKG_USING_MRAMTRACE
+    bool "MRamTrace: low-overhead RAM-based function tracing"
+    default n
+    help
+        MRamTrace is a lightweight, RAM-resident function tracer for
+        microcontrollers. It uses GCC/Clang -finstrument-functions to capture
+        function enter/exit events into a ring buffer, then exports them for
+        offline call-graph / flamegraph analysis (Perfetto, Speedscope,
+        KCachegrind, FlameGraph).
+
+if PKG_USING_MRAMTRACE
+
+    config PKG_MRAMTRACE_USING_DEMO
+        bool "Enable the RT-Thread demo"
+        default y
+        help
+            Builds a demo that runs a signal-processing workload (compiled with
+            -finstrument-functions), captures a trace window, and exports the
+            events to the console via the `ram_trace_demo` shell command.
+
+    config PKG_MRAMTRACE_DEMO_CPU_HZ
+        int "Demo timestamp frequency (CPU clock Hz)"
+        default 168000000
+        depends on PKG_MRAMTRACE_USING_DEMO
+        help
+            CPU clock frequency in Hz, used to convert the Cortex-M DWT cycle
+            counter timestamps into wall-clock time. Set this to the actual
+            core clock of your target.
+
+endif

--- a/tools/MRamTrace/package.json
+++ b/tools/MRamTrace/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "MRamTrace",
+  "description": "MRamTrace is a lightweight RAM-backed function tracing and offline visualization tool for MCU firmware. It captures function enter/exit events via GCC/Clang -finstrument-functions into a ring buffer, then exports them (UART, log, file, Bluetooth, or custom backend) for offline call-graph, flamegraph, Perfetto, Speedscope and KCachegrind analysis.",
+  "description_zh": "MRamTrace 是一款轻量级基于 RAM 的 MCU 函数追踪与离线可视化工具，通过 GCC/Clang 的 -finstrument-functions 将函数进入/退出事件写入环形缓冲区，冻结后通过 UART、日志、文件、蓝牙或自定义后端导出，结合 ELF 生成调用图、火焰图、Perfetto、Speedscope 和 KCachegrind 等离线分析数据。",
+  "enable": "PKG_USING_MRAMTRACE",
+  "keywords": [
+    "trace",
+    "profiling",
+    "flamegraph",
+    "callgraph",
+    "perf",
+    "instrument"
+  ],
+  "category": "tools",
+  "author": {
+    "name": "hanzhijian",
+    "email": "hanzhijian1991@gmail.com",
+    "github": "Zepp-Hanzj"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/Zepp-Hanzj/MRamTrace",
+  "homepage": "https://github.com/Zepp-Hanzj/MRamTrace#readme",
+  "doc": "https://github.com/Zepp-Hanzj/MRamTrace/blob/main/README.md",
+  "readme": "MRamTrace is a lightweight RAM-backed function tracing and offline visualization tool for MCU firmware. It captures function enter/exit events via GCC/Clang -finstrument-functions into a ring buffer, then exports them for offline call-graph, flamegraph, Perfetto, Speedscope and KCachegrind analysis.",
+  "site": [
+    {
+      "version": "latest",
+      "URL": "https://github.com/Zepp-Hanzj/MRamTrace.git",
+      "filename": "MRamTrace.zip",
+      "VER_SHA": "main"
+    }
+  ]
+}

--- a/tools/MRamTrace/package.json
+++ b/tools/MRamTrace/package.json
@@ -27,7 +27,7 @@
       "version": "latest",
       "URL": "https://github.com/Zepp-Hanzj/MRamTrace.git",
       "filename": "MRamTrace.zip",
-      "VER_SHA": "main"
+      "VER_SHA": "81c2e76605c87eb387b06c98b8ab1162a655e888"
     }
   ]
 }


### PR DESCRIPTION
## 包介绍 / Package Description

MRamTrace 是一款轻量级基于 RAM 的 MCU 函数追踪与离线可视化工具。通过 GCC/Clang 的 `-finstrument-functions` 将函数进入/退出事件写入环形缓冲区，冻结后导出，结合 ELF 生成火焰图、调用图、Perfetto、Speedscope 等离线分析数据。

MRamTrace is a lightweight RAM-backed function tracing and offline visualization tool for MCU firmware.

## 仓库 / Repository

- GitHub: https://github.com/Zepp-Hanzj/MRamTrace
- License: MIT

## 特性 / Features

- 16 字节固定事件，低开销，纯软件插桩，无 ETM/SWO 依赖
- 支持多上下文（任务 / 中断 / 空闲）
- RT-Thread port：利用 `rt_thread_self()` 免任务切换 hook
- 主机端分析器：火焰图、KCachegrind、Chrome Tracing、Speedscope

## 验证 / Validation

已在 STM32F407（lxb407zgt6）实测：1200 事件、100% 覆盖、0 未解析符号，成功生成火焰图 / callgrind / chrome-trace。

## 修改文件 / Files

- tools/MRamTrace/package.json
- tools/MRamTrace/Kconfig
- tools/Kconfig（注册 source）