### PR TITLE
[optparse] add v1.0.0 version entry to restore rollback capability

### DIFF
--- a/misc/optparse/Kconfig
+++ b/misc/optparse/Kconfig
@@ -16,10 +16,14 @@ if PKG_USING_OPTPARSE
 
         config PKG_USING_OPTPARSE_LATEST_VERSION
             bool "latest"
+
+        config PKG_USING_OPTPARSE_V100
+            bool "v1.0.0"
     endchoice
 
     config PKG_OPTPARSE_VER
         string
+        default "v1.0.0" if PKG_USING_OPTPARSE_V100
         default "latest" if PKG_USING_OPTPARSE_LATEST_VERSION
 
     config OPTPARSE_USING_DEMO

--- a/misc/optparse/package.json
+++ b/misc/optparse/package.json
@@ -17,6 +17,12 @@
     "homepage": "https://github.com/RT-Thread-packages/optparse#readme",
     "site": [
         {
+            "version": "v1.0.0",
+            "URL": "https://github.com/RT-Thread-packages/optparse.git",
+            "filename": "optparse-v1.0.0.zip",
+            "VER_SHA": "98a75bb7c422e88eab9da8eb1b57608a8f303059"
+        },
+        {
             "version": "latest",
             "URL": "https://github.com/RT-Thread-packages/optparse.git",
             "filename": "optparse-latest.zip",


### PR DESCRIPTION
## 背景

optparse 在 RT-Thread-packages/optparse@07a365d（add argc to struct optparse）中
将 `optparse_init` 从 2 参数改为 3 参数（新增 `int argc`），属于破坏性接口变更。

此变更导致依赖 2 参接口的既有软件包编译失败，例如 wavplayer v0.2.0：
error: too few arguments to function 'optparse_init'

## 问题

当前包索引中 optparse 仅收录 latest 版本，用户（含 RT-Thread Studio 用户）
无法回退到旧版本，只能手动修改第三方包源码。

## 本 PR 的改动

为 optparse 恢复 v1.0.0 版本条目（package.json + Kconfig）：
- VER_SHA 指向 98a75bb（即 argc 变更前的 2 参数版本），与官方 SDK demo
  中实际使用的 optparse-v1.0.0 一致
- 用户遇到新版不兼容时可在 menuconfig / Studio Settings 中直接选择 v1.0.0 回退
- 不影响 latest 的默认行为

## 验证

- package.json 已通过 JSON 格式校验
- Kconfig 选项命名遵循包索引惯例（参考 aht10 的 V100/V210/V300 写法）