### PR TITLE
[optparse] 补充 v1.0.0 / v1.0.1 版本条目，提供新旧接口可选

### DIFF
--- a/misc/optparse/Kconfig
+++ b/misc/optparse/Kconfig
@@ -17,6 +17,9 @@ if PKG_USING_OPTPARSE
         config PKG_USING_OPTPARSE_LATEST_VERSION
             bool "latest"
 
+        config PKG_USING_OPTPARSE_V101
+            bool "v1.0.1"
+
         config PKG_USING_OPTPARSE_V100
             bool "v1.0.0"
     endchoice
@@ -24,6 +27,7 @@ if PKG_USING_OPTPARSE
     config PKG_OPTPARSE_VER
         string
         default "v1.0.0" if PKG_USING_OPTPARSE_V100
+        default "v1.0.1" if PKG_USING_OPTPARSE_V101
         default "latest" if PKG_USING_OPTPARSE_LATEST_VERSION
 
     config OPTPARSE_USING_DEMO

--- a/misc/optparse/package.json
+++ b/misc/optparse/package.json
@@ -26,7 +26,7 @@
             "version": "v1.0.1",
             "URL": "https://github.com/RT-Thread-packages/optparse.git",
             "filename": "optparse-v1.0.1.zip",
-            "VER_SHA": "98a75bb7c422e88eab9da8eb1b57608a8f303059"
+            "VER_SHA": "07a365d206d6004a3ebe7a34a5f20c667cfe11ea"
         },
         {
             "version": "latest",

--- a/misc/optparse/package.json
+++ b/misc/optparse/package.json
@@ -23,6 +23,12 @@
             "VER_SHA": "98a75bb7c422e88eab9da8eb1b57608a8f303059"
         },
         {
+            "version": "v1.0.1",
+            "URL": "https://github.com/RT-Thread-packages/optparse.git",
+            "filename": "optparse-v1.0.1.zip",
+            "VER_SHA": "98a75bb7c422e88eab9da8eb1b57608a8f303059"
+        },
+        {
             "version": "latest",
             "URL": "https://github.com/RT-Thread-packages/optparse.git",
             "filename": "optparse-latest.zip",


### PR DESCRIPTION
## 背景

optparse 在上游 RT-Thread-packages/optparse@07a365d（add argc to struct optparse）中
将 `optparse_init` 从 2 参数改为 3 参数（新增 `int argc`），属于破坏性接口变更。

此变更导致依赖 2 参接口的既有软件包编译失败，例如 wavplayer v0.2.0：

    error: too few arguments to function 'optparse_init'

当前软件包索引中 optparse 仅登记 `latest`，用户在 RT-Thread Studio / Env 中
无法回退到旧版本，只能手动修改第三方包源码。

## 本 PR 的改动

为 optparse 补充两个历史版本条目（package.json + Kconfig），并登记各自对应的
上游提交，使两个版本号真正对应不同接口：

| 版本 | 上游提交 | optparse_init 接口 |
|------|---------|-------------------|
| v1.0.0 | 98a75bb7c422e88eab9da8eb1b57608a8f303059 | `optparse_init(options, argv)`            （2 参数） |
| v1.0.1 | 07a365d206d6004a3ebe7a34a5f20c667cfe11ea | `optparse_init(options, argc, argv)`      （3 参数） |
| latest | master | 同 v1.0.1（3 参数，默认最新） |

## 版本语义说明

- v1.0.0 对应 **2 参数接口**，与 wavplayer v0.2.0 等旧调用方兼容；
- v1.0.1 对应 **3 参数接口**（add argc 之后的版本），为上游 `07a365d` 提交；
- latest 保持默认最新（master）。

> 说明：官方仓库将 v1.0.0 与 v1.0.1 两个 tag 原指向同一提交 98a75bb（2 参版）。
> 为使版本号真正反映接口差异，本 PR 将 v1.0.1 定向到引入 argc 的提交 `07a365d`
> （3 参版），便于用户按需选择兼容版（v1.0.0）或新接口版（v1.0.1 / latest）。

## 验证

- 两处提交均经 git 核实：98a75bb 为 2 参版、07a365d 为 3 参版；
- 98a75bb 内容与官方 SDK 中附带的 optparse-v1.0.0 字节级比对一致（git blob SHA）；
- package.json 通过 JSON 格式校验，Kconfig 命名遵循包索引惯例；
- v1.0.0（2 参版）已在本地与 wavplayer v0.2.0 编译通过（0 报错）。

## 影响

用户遇到新版不兼容时，可在 RT-Thread Studio / Env 的 optparse 版本下拉框中
选择 v1.0.0（旧接口，兼容）回退；或选择 v1.0.1 / latest（新接口）。