### PR TITLE
refactor(autogen_parameter_manager): 调整Kconfig配置选项默认值

### DIFF
--- a/misc/autogen_parameter_manager/Kconfig
+++ b/misc/autogen_parameter_manager/Kconfig
@@ -2,8 +2,6 @@
 menuconfig PKG_USING_AUTOGEN_PARAMETER_MANAGER
     bool "autogen_parameter_manager: parameter table management library"
     default n
-    select RT_USING_HEAP
-    select RT_USING_CAN
     help
         RT-Thread package wrapper for autogen_parameter_manager.
 
@@ -239,7 +237,7 @@ if PKG_USING_AUTOGEN_PARAMETER_MANAGER
 
         config AUTOGEN_PM_USING_NVM
             bool "Enable parameter persistent-storage support"
-            default y
+            default n
             help
                 Enable par_nvm.c and the abstract parameter-storage backend
                 interface. Select one packaged backend adapter.
@@ -278,7 +276,7 @@ if PKG_USING_AUTOGEN_PARAMETER_MANAGER
 
         config AUTOGEN_PM_NVM_OBJECT
             bool "Enable object parameter persistence"
-            default y
+            default n
             depends on AUTOGEN_PM_USING_NVM && AUTOGEN_PM_ENABLE_ID && AUTOGEN_PM_ENABLE_TYPE_OBJECT
             help
                 Store STR, BYTES, ARR_U8, ARR_U16, and ARR_U32 payloads in a


### PR DESCRIPTION
移除了对RT_USING_HEAP和RT_USING_CAN的依赖选择，
将AUTOGEN_PM_USING_NVM和AUTOGEN_PM_NVM_OBJECT的默认值
从y改为n，以提供更灵活的配置
https://github.com/RT-Thread/packages/issues/2035